### PR TITLE
Fix issue #3

### DIFF
--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElementFactory.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElementFactory.java
@@ -2,14 +2,15 @@ package com.github.stefvanschie.quickskript.psi;
 
 import com.github.stefvanschie.quickskript.psi.function.*;
 import com.github.stefvanschie.quickskript.psi.literal.PsiNumber;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.time.LocalDateTime;
+import java.util.*;
 
 /**
  * A factory for creating psi elements from text
@@ -17,13 +18,13 @@ import java.util.Set;
  * @since 0.1.0
  */
 public class PsiElementFactory {
-
+    
     /**
      * A list of all possible factories available
      */
     @NotNull
     private static final Set<PsiFactory> FACTORIES = new HashSet<>();
-
+    
     /**
      * A class which holds a psi element class and it's return type
      */
@@ -37,7 +38,7 @@ public class PsiElementFactory {
      */
     @NotNull
     private static final Map<Class<? extends PsiElement<?>>, Class<?>> CLASS_TYPES = new HashMap<>();
-
+    
     /**
      * Parses text into psi elements. May return null if no element was found.
      *
@@ -49,58 +50,77 @@ public class PsiElementFactory {
     @Contract("null, _ -> fail")
     public static PsiElement<?> parseText(@NotNull String input, @NotNull Class<?> classType) {
         input = input.trim();
-
+        
         for (PsiFactory<?> factory : FACTORIES) {
             PsiElement<?> element = factory.parse(input);
-
+            
             if (element != null && classType.isAssignableFrom(CLASS_TYPES.get(element.getClass())))
                 return element;
         }
-
+        
         return null;
     }
-
-    /**
-     * Returns the class types map
-     *
-     * @return the class types
-     * @since 0.1.0
-     */
-    @NotNull
-    @Contract(pure = true)
-    public static Map<Class<? extends PsiElement<?>>, Class<?>> getClassTypes() {
-        return CLASS_TYPES;
-    }
-
+    
     static {
         //functions
-        FACTORIES.add(new PsiAbsoluteValueFunction.Factory());
-        FACTORIES.add(new PsiAtan2Function.Factory());
-        FACTORIES.add(new PsiCalculateExperienceFunction.Factory());
-        FACTORIES.add(new PsiCeilFunction.Factory());
-        FACTORIES.add(new PsiCosineFunction.Factory());
-        FACTORIES.add(new PsiDateFunction.Factory());
-        FACTORIES.add(new PsiExponentialFunction.Factory());
-        FACTORIES.add(new PsiFloorFunction.Factory());
-        FACTORIES.add(new PsiInverseCosineFunction.Factory());
-        FACTORIES.add(new PsiInverseSineFunction.Factory());
-        FACTORIES.add(new PsiInverseTangentFunction.Factory());
-        FACTORIES.add(new PsiLocationFunction.Factory());
-        FACTORIES.add(new PsiLogarithmFunction.Factory());
-        FACTORIES.add(new PsiMaximumFunction.Factory());
-        FACTORIES.add(new PsiMinimumFunction.Factory());
-        FACTORIES.add(new PsiModuloFunction.Factory());
-        FACTORIES.add(new PsiNaturalLogarithmFunction.Factory());
-        FACTORIES.add(new PsiProductFunction.Factory());
-        FACTORIES.add(new PsiRoundFunction.Factory());
-        FACTORIES.add(new PsiSineFunction.Factory());
-        FACTORIES.add(new PsiSquareRootFunction.Factory());
-        FACTORIES.add(new PsiSumFunction.Factory());
-        FACTORIES.add(new PsiTangentFunction.Factory());
-        FACTORIES.add(new PsiVectorFunction.Factory());
-        FACTORIES.add(new PsiWorldFunction.Factory());
-
+        registerElement(PsiAbsoluteValueFunction.class, Double.class, new PsiAbsoluteValueFunction.Factory());
+        registerElement(PsiAtan2Function.class, Double.class, new PsiAtan2Function.Factory());
+        registerElement(PsiCalculateExperienceFunction.class, Long.class, new PsiCalculateExperienceFunction.Factory());
+        registerElement(PsiCeilFunction.class, Double.class, new PsiCeilFunction.Factory());
+        registerElement(PsiCosineFunction.class, Double.class, new PsiCosineFunction.Factory());
+        registerElement(PsiDateFunction.class, LocalDateTime.class, new PsiDateFunction.Factory());
+        registerElement(PsiExponentialFunction.class, Double.class, new PsiExponentialFunction.Factory());
+        registerElement(PsiFloorFunction.class, Double.class, new PsiFloorFunction.Factory());
+        registerElement(PsiInverseCosineFunction.class, Double.class, new PsiInverseCosineFunction.Factory());
+        registerElement(PsiInverseSineFunction.class, Double.class, new PsiInverseSineFunction.Factory());
+        registerElement(PsiInverseTangentFunction.class, Double.class, new PsiInverseTangentFunction.Factory());
+        registerElement(PsiLocationFunction.class, Location.class, new PsiLocationFunction.Factory());
+        registerElement(PsiLogarithmFunction.class, Double.class, new PsiLogarithmFunction.Factory());
+        registerElement(PsiMaximumFunction.class, Double.class, new PsiMaximumFunction.Factory());
+        registerElement(PsiMinimumFunction.class, Double.class, new PsiMinimumFunction.Factory());
+        registerElement(PsiModuloFunction.class, Double.class, new PsiModuloFunction.Factory());
+        registerElement(PsiNaturalLogarithmFunction.class, Double.class, new PsiNaturalLogarithmFunction.Factory());
+        registerElement(PsiProductFunction.class, Double.class, new PsiProductFunction.Factory());
+        registerElement(PsiRoundFunction.class, Long.class, new PsiRoundFunction.Factory());
+        registerElement(PsiSineFunction.class, Double.class, new PsiSineFunction.Factory());
+        registerElement(PsiSquareRootFunction.class, Double.class, new PsiSquareRootFunction.Factory());
+        registerElement(PsiSumFunction.class, Double.class, new PsiSumFunction.Factory());
+        registerElement(PsiTangentFunction.class, Double.class, new PsiTangentFunction.Factory());
+        registerElement(PsiVectorFunction.class, Vector.class, new PsiVectorFunction.Factory());
+        registerElement(PsiWorldFunction.class, World.class, new PsiWorldFunction.Factory());
+        
         //literals
-        FACTORIES.add(new PsiNumber.Factory());
+        registerElement(PsiNumber.class, Double.class, new PsiNumber.Factory());
+    }
+    
+    /**
+     * Registers the specified {@link PsiElement} by linking its {@link Class}
+     * to its return type ({@link Class}) and by saving its {@link PsiFactory}.
+     *
+     * @param elementClass the class of the {@link PsiElement} being registered
+     * @param elementReturnType the return type of the {@link PsiElement} being registered
+     * @param elementFactory the {@link PsiFactory} of the {@link PsiElement} being registered
+     * @since 0.1.0
+     */
+    private static void registerElement(Class<? extends PsiElement<?>> elementClass, Class<?> elementReturnType,
+                                        PsiFactory<? extends PsiElement<?>> elementFactory) {
+        CLASS_TYPES.put(elementClass, elementReturnType);
+        FACTORIES.add(elementFactory);
+    }
+    
+    /**
+     * Registers the specified {@link PsiElement} by linking its {@link Class}
+     * to its return type ({@link Class}) and by saving its {@link PsiFactory}.
+     *
+     * @param elementClass the class of the {@link PsiElement} being registered
+     * @param elementReturnType the return type of the {@link PsiElement} being registered
+     * @param elementFactories the {@link PsiFactory}s of the {@link PsiElement} being registered
+     * @since 0.1.0
+     */
+    @SafeVarargs
+    private static void registerElement(Class<? extends PsiElement<?>> elementClass, Class<?> elementReturnType,
+                                        PsiFactory<? extends PsiElement<?>>... elementFactories) {
+        CLASS_TYPES.put(elementClass, elementReturnType);
+        FACTORIES.addAll(Arrays.asList(elementFactories));
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElementFactory.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElementFactory.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.psi;
 
 import com.github.stefvanschie.quickskript.psi.function.*;
 import com.github.stefvanschie.quickskript.psi.literal.PsiNumber;
+import org.apache.commons.lang3.Validate;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.util.Vector;
@@ -102,8 +103,8 @@ public class PsiElementFactory {
      * @param elementFactory the {@link PsiFactory} of the {@link PsiElement} being registered
      * @since 0.1.0
      */
-    private static void registerElement(Class<? extends PsiElement<?>> elementClass, Class<?> elementReturnType,
-                                        PsiFactory<? extends PsiElement<?>> elementFactory) {
+    private static void registerElement(@NotNull Class<? extends PsiElement<?>> elementClass, @NotNull Class<?> elementReturnType,
+                                        @NotNull PsiFactory<? extends PsiElement<?>> elementFactory) {
         CLASS_TYPES.put(elementClass, elementReturnType);
         FACTORIES.add(elementFactory);
     }
@@ -118,8 +119,10 @@ public class PsiElementFactory {
      * @since 0.1.0
      */
     @SafeVarargs
-    private static void registerElement(Class<? extends PsiElement<?>> elementClass, Class<?> elementReturnType,
-                                        PsiFactory<? extends PsiElement<?>>... elementFactories) {
+    private static void registerElement(@NotNull Class<? extends PsiElement<?>> elementClass, @NotNull Class<?> elementReturnType,
+                                        @NotNull PsiFactory<? extends PsiElement<?>>... elementFactories) {
+        Validate.notEmpty(elementFactories);
+        Validate.noNullElements(elementFactories);
         CLASS_TYPES.put(elementClass, elementReturnType);
         FACTORIES.addAll(Arrays.asList(elementFactories));
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElementFactory.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElementFactory.java
@@ -105,8 +105,9 @@ public class PsiElementFactory {
      */
     private static void registerElement(@NotNull Class<? extends PsiElement<?>> elementClass, @NotNull Class<?> elementReturnType,
                                         @NotNull PsiFactory<? extends PsiElement<?>> elementFactory) {
-        CLASS_TYPES.put(elementClass, elementReturnType);
-        FACTORIES.add(elementFactory);
+        Validate.isTrue(CLASS_TYPES.put(elementClass, elementReturnType) == null,
+				"The specified PsiElement has already been registered!");
+		Validate.isTrue(FACTORIES.add(elementFactory), "The specified PsiFactory has already been registered!");
     }
     
     /**
@@ -123,7 +124,10 @@ public class PsiElementFactory {
                                         @NotNull PsiFactory<? extends PsiElement<?>>... elementFactories) {
         Validate.notEmpty(elementFactories);
         Validate.noNullElements(elementFactories);
-        CLASS_TYPES.put(elementClass, elementReturnType);
-        FACTORIES.addAll(Arrays.asList(elementFactories));
+		Validate.isTrue(CLASS_TYPES.put(elementClass, elementReturnType) == null,
+				"The specified PsiElement has already been registered!");
+		for (PsiFactory<? extends PsiElement<?>> factory : elementFactories) {
+			Validate.isTrue(FACTORIES.add(factory), factory.getClass().getName() + " has already been registered!");
+		}
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiAbsoluteValueFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiAbsoluteValueFunction.java
@@ -71,8 +71,4 @@ public class PsiAbsoluteValueFunction implements PsiElement<Double> {
             return new PsiAbsoluteValueFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiAbsoluteValueFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiAtan2Function.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiAtan2Function.java
@@ -80,8 +80,4 @@ public class PsiAtan2Function implements PsiElement<Double> {
             return new PsiAtan2Function(xElement, yElement);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiAtan2Function.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCalculateExperienceFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCalculateExperienceFunction.java
@@ -84,8 +84,4 @@ public class PsiCalculateExperienceFunction implements PsiElement<Long> {
             return new PsiCalculateExperienceFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiCalculateExperienceFunction.class, Long.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCeilFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCeilFunction.java
@@ -72,8 +72,4 @@ public class PsiCeilFunction implements PsiElement<Double> {
             return new PsiCeilFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiCeilFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCosineFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCosineFunction.java
@@ -71,8 +71,4 @@ public class PsiCosineFunction implements PsiElement<Double> {
             return new PsiCosineFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiCosineFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiDateFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiDateFunction.java
@@ -116,8 +116,4 @@ public class PsiDateFunction implements PsiElement<LocalDateTime> {
             );
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiDateFunction.class, LocalDateTime.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiExponentialFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiExponentialFunction.java
@@ -72,8 +72,4 @@ public class PsiExponentialFunction implements PsiElement<Double> {
             return new PsiExponentialFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiExponentialFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiFloorFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiFloorFunction.java
@@ -72,8 +72,4 @@ public class PsiFloorFunction implements PsiElement<Double> {
             return new PsiFloorFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiFloorFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseCosineFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseCosineFunction.java
@@ -71,8 +71,4 @@ public class PsiInverseCosineFunction implements PsiElement<Double> {
             return new PsiInverseCosineFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiInverseCosineFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseSineFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseSineFunction.java
@@ -72,8 +72,4 @@ public class PsiInverseSineFunction implements PsiElement<Double> {
             return new PsiInverseSineFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiInverseSineFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseTangentFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseTangentFunction.java
@@ -72,8 +72,4 @@ public class PsiInverseTangentFunction implements PsiElement<Double> {
             return new PsiInverseTangentFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiInverseTangentFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiLocationFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiLocationFunction.java
@@ -125,8 +125,4 @@ public class PsiLocationFunction implements PsiElement<Location> {
             );
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiLocationFunction.class, Location.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiLogarithmFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiLogarithmFunction.java
@@ -94,8 +94,4 @@ public class PsiLogarithmFunction implements PsiElement<Double> {
             return new PsiLogarithmFunction(value, base);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiLogarithmFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMaximumFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMaximumFunction.java
@@ -110,8 +110,4 @@ public class PsiMaximumFunction implements PsiElement<Double> {
             return new PsiMaximumFunction(numbers);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiMaximumFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMinimumFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMinimumFunction.java
@@ -110,8 +110,4 @@ public class PsiMinimumFunction implements PsiElement<Double> {
             return new PsiMinimumFunction(numbers);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiMinimumFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiModuloFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiModuloFunction.java
@@ -82,8 +82,4 @@ public class PsiModuloFunction implements PsiElement<Double> {
             return new PsiModuloFunction(a, b);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiModuloFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiNaturalLogarithmFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiNaturalLogarithmFunction.java
@@ -72,8 +72,4 @@ public class PsiNaturalLogarithmFunction implements PsiElement<Double> {
             return new PsiNaturalLogarithmFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiNaturalLogarithmFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiProductFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiProductFunction.java
@@ -118,8 +118,4 @@ public class PsiProductFunction implements PsiElement<Double> {
             return new PsiProductFunction(numbers);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiProductFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiRoundFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiRoundFunction.java
@@ -73,8 +73,4 @@ public class PsiRoundFunction implements PsiElement<Long> {
             return new PsiRoundFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiRoundFunction.class, Long.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSineFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSineFunction.java
@@ -72,8 +72,4 @@ public class PsiSineFunction implements PsiElement<Double> {
             return new PsiSineFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiSineFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSquareRootFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSquareRootFunction.java
@@ -72,8 +72,4 @@ public class PsiSquareRootFunction implements PsiElement<Double> {
             return new PsiSquareRootFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiSquareRootFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSumFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSumFunction.java
@@ -109,8 +109,4 @@ public class PsiSumFunction implements PsiElement<Double> {
             return new PsiSumFunction(numbers);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiSumFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiTangentFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiTangentFunction.java
@@ -72,8 +72,4 @@ public class PsiTangentFunction implements PsiElement<Double> {
             return new PsiTangentFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiTangentFunction.class, Double.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiVectorFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiVectorFunction.java
@@ -90,8 +90,4 @@ public class PsiVectorFunction implements PsiElement<Vector> {
             return new PsiVectorFunction(x, y, z);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiVectorFunction.class, Vector.class);
-    }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiWorldFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiWorldFunction.java
@@ -74,8 +74,4 @@ public class PsiWorldFunction implements PsiElement<World> {
             return new PsiWorldFunction(element);
         }
     }
-
-    static {
-        PsiElementFactory.getClassTypes().put(PsiWorldFunction.class, World.class);
-    }
 }


### PR DESCRIPTION
The commit in this PR fixes issue #3. The `PsiElementFactory.getClassTypes` method is removed, the static initializers in the `psi.function` package are also removed and a `PsiElementFactory.registerElement` method, which is overloaded once, is added as a result. The `PsiNumber` literal was previously not registered in `CLASS_TYPES`, this PR also takes care of that. The `PsiElementFactory.registerElement` has an overloaded version which enables multiple `PsiFactory`s to be registered simultaneously because `PsiFactory`'s documentation state that a `PsiElement` may have multiple factories.