### PR TITLE
Methods which internally throw the exceptions

### DIFF
--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElement.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElement.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.psi;
 
 import com.github.stefvanschie.quickskript.context.Context;
+import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,7 +20,7 @@ public abstract class PsiElement<T> {
     protected T preComputed;
 
     /**
-     * Returns a pre computed value if {@link #isPreComputed()} returns true otherwise executes this element
+     * Returns a pre computed value if {@link #isPreComputed()} returns true otherwise executes this element.
      *
      * @param context the context this code is being executed in, may be null if the code is expected to be pre computed
      * @return the computed value which is null if the computation returned null
@@ -27,6 +28,25 @@ public abstract class PsiElement<T> {
      */
     public final T execute(@Nullable Context context) {
         return isPreComputed() ? preComputed : executeImpl(context);
+    }
+
+    /**
+     * Returns a pre computed value if {@link #isPreComputed()} returns true otherwise executes this element.
+     * If the result is not an instance of the specified {@link Class} an {@link ExecutionException} is thrown.
+     *
+     * @param context the context this code is being executed in, may be null if the code is expected to be pre computed
+     * @param forcedResult the {@link Class} this method must return an instance of
+     * @param <R> the type this method must return an instance of
+     * @return the computed value which is null if the computation returned null
+     * @since 0.1.0
+     */
+    public <R> R execute(@Nullable Context context, Class<R> forcedResult) {
+        T result = execute(context);
+        if (forcedResult.isInstance(result))
+            return forcedResult.cast(result);
+
+        throw new ExecutionException("Result of " + getClass().getSimpleName() +
+                " should be a " + forcedResult.getSimpleName() + ", but it wasn't");
     }
 
     /**

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiCancelEventEffect.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiCancelEventEffect.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.context.EventContext;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
+import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -24,7 +25,8 @@ public class PsiCancelEventEffect extends PsiElement<Void> {
      *
      * @since 0.1.0
      */
-    private PsiCancelEventEffect() {}
+    private PsiCancelEventEffect() {
+    }
 
     /**
      * {@inheritDoc}
@@ -32,12 +34,12 @@ public class PsiCancelEventEffect extends PsiElement<Void> {
     @Override
     protected Void executeImpl(@Nullable Context context) {
         if (!(context instanceof EventContext))
-            throw new IllegalStateException("Code is not being run from an event and thus can't cancel anything.");
+            throw new ExecutionException("Code is not being run from an event and thus can't cancel anything.");
 
         Event event = ((EventContext) context).getEvent();
 
         if (!(event instanceof Cancellable))
-            throw new UnsupportedOperationException("This event cannot be cancelled.");
+            throw new ExecutionException("This event cannot be cancelled.");
 
         ((Cancellable) event).setCancelled(true);
 

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/expression/PsiParseExpression.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/expression/PsiParseExpression.java
@@ -4,7 +4,6 @@ import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiConverter;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -87,17 +86,11 @@ public class PsiParseExpression extends PsiElement<Object> {
 
             String valueString = matcher.group(1);
 
-            PsiElement<?> value = SkriptLoader.get().tryParseElement(valueString);
-
-            if (value == null)
-                throw new ParseException("Expression was unable to find an expression named " + valueString);
+            PsiElement<?> value = SkriptLoader.get().forceParseElement(valueString);
 
             String factoryString = matcher.group(2);
 
-            PsiConverter<?> converter = SkriptLoader.get().getConverter(factoryString);
-
-            if (converter == null)
-                throw new ParseException("Expression was unable to find a factory named " + factoryString);
+            PsiConverter<?> converter = SkriptLoader.get().forceGetConverter(factoryString);
 
             return new PsiParseExpression(value, converter);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiAbsoluteValueFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiAbsoluteValueFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,12 +42,7 @@ public class PsiAbsoluteValueFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.abs(((Number) result).doubleValue());
+        return Math.abs(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -76,10 +69,7 @@ public class PsiAbsoluteValueFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiAbsoluteValueFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiAtan2Function.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiAtan2Function.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -47,17 +45,7 @@ public class PsiAtan2Function extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object xResult = x.execute(context);
-
-        if (!(xResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object yResult = y.execute(context);
-
-        if (!(yResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.atan2(((Number) xResult).doubleValue(), ((Number) yResult).doubleValue());
+        return Math.atan2(x.execute(context, Number.class).doubleValue(), y.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -84,16 +72,10 @@ public class PsiAtan2Function extends PsiElement<Double> {
                 return null;
 
             String xExpression = matcher.group(1);
-            PsiElement<?> xElement = SkriptLoader.get().tryParseElement(xExpression);
-
-            if (xElement == null)
-                throw new ParseException("Function was unable to find an expression named " + xExpression);
+            PsiElement<?> xElement = SkriptLoader.get().forceParseElement(xExpression);
 
             String yExpression = matcher.group(2);
-            PsiElement<?> yElement = SkriptLoader.get().tryParseElement(yExpression);
-
-            if (yElement == null)
-                throw new ParseException("Function was unable to find an expression named " + yExpression);
+            PsiElement<?> yElement = SkriptLoader.get().forceParseElement(yExpression);
 
             return new PsiAtan2Function(xElement, yElement);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCalculateExperienceFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCalculateExperienceFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiCalculateExperienceFunction extends PsiElement<Long> {
     @NotNull
     @Override
     protected Long executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        long level = ((Number) result).longValue();
+        long level = parameter.execute(context, Number.class).longValue();
         long exp = 0;
 
         if (level > 0) {
@@ -89,10 +82,7 @@ public class PsiCalculateExperienceFunction extends PsiElement<Long> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiCalculateExperienceFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCeilFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCeilFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiCeilFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.ceil(((Number) result).doubleValue());
+        return Math.ceil(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiCeilFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiCeilFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCosineFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiCosineFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,12 +42,7 @@ public class PsiCosineFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.cos(((Number) result).doubleValue());
+        return Math.cos(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -76,10 +69,7 @@ public class PsiCosineFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiCosineFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiDateFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiDateFunction.java
@@ -3,7 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,9 +55,9 @@ public class PsiDateFunction extends PsiElement<LocalDateTime> {
         this.millisecond = millisecond;
 
         if (this.year.isPreComputed() && this.month.isPreComputed() && this.day.isPreComputed() &&
-            (this.hour == null || this.hour.isPreComputed()) && (this.minute == null || this.minute.isPreComputed()) &&
-            (this.second == null || this.second.isPreComputed()) &&
-            (this.millisecond == null || this.millisecond.isPreComputed())) {
+                (this.hour == null || this.hour.isPreComputed()) && (this.minute == null || this.minute.isPreComputed()) &&
+                (this.second == null || this.second.isPreComputed()) &&
+                (this.millisecond == null || this.millisecond.isPreComputed())) {
             preComputed = executeImpl(null);
             this.year = this.month = this.day = this.hour = this.minute = this.second = this.millisecond = null;
         }
@@ -70,49 +69,14 @@ public class PsiDateFunction extends PsiElement<LocalDateTime> {
     @NotNull
     @Override
     protected LocalDateTime executeImpl(@Nullable Context context) {
-        Object yearResult = year.execute(context);
-
-        if (!(yearResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object monthResult = month.execute(context);
-
-        if (!(monthResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object dayResult = day.execute(context);
-
-        if (!(dayResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object hourResult = hour == null ? null : hour.execute(context);
-
-        if (hourResult != null && !(hourResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object minuteResult = minute == null ? null : minute.execute(context);
-
-        if (minuteResult != null && !(minuteResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object secondResult = second == null ? null : second.execute(context);
-
-        if (secondResult != null && !(secondResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object millisecondResult = millisecond == null ? null : millisecond.execute(context);
-
-        if (millisecondResult != null && !(millisecondResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
         return LocalDateTime.of(
-            ((Number) yearResult).intValue(),
-            ((Number) monthResult).intValue(),
-            ((Number) dayResult).intValue(),
-            hourResult == null ? 0 : ((Number) hourResult).intValue(),
-            minuteResult == null ? 0 : ((Number) minuteResult).intValue(),
-            secondResult == null ? 0 : ((Number) secondResult).intValue(),
-            millisecondResult == null ? 0 : ((Number) millisecondResult).intValue() * 1000000
+                year.execute(context, Number.class).intValue(),
+                month.execute(context, Number.class).intValue(),
+                day.execute(context, Number.class).intValue(),
+                hour == null ? 0 : hour.execute(context, Number.class).intValue(),
+                minute == null ? 0 : minute.execute(context, Number.class).intValue(),
+                second == null ? 0 : second.execute(context, Number.class).intValue(),
+                millisecond == null ? 0 : millisecond.execute(context, Number.class).intValue() * 1000000
         );
     }
 
@@ -147,16 +111,16 @@ public class PsiDateFunction extends PsiElement<LocalDateTime> {
             List<PsiElement<?>> elements = new ArrayList<>(Math.min(values.length, 7));
 
             for (int i = 0; i < values.length; i++)
-                elements.add(i, SkriptLoader.get().tryParseElement(values[i]));
+                elements.add(i, SkriptLoader.get().forceParseElement(values[i]));
 
             return new PsiDateFunction(
-                elements.get(0),
-                elements.get(1),
-                elements.get(2),
-                elements.size() > 3 ? elements.get(3) : null,
-                elements.size() > 4 ? elements.get(4) : null,
-                elements.size() > 5 ? elements.get(5) : null,
-                elements.size() > 6 ? elements.get(6) : null
+                    elements.get(0),
+                    elements.get(1),
+                    elements.get(2),
+                    elements.size() > 3 ? elements.get(3) : null,
+                    elements.size() > 4 ? elements.get(4) : null,
+                    elements.size() > 5 ? elements.get(5) : null,
+                    elements.size() > 6 ? elements.get(6) : null
             );
         }
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiExponentialFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiExponentialFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiExponentialFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.exp(((Number) result).doubleValue());
+        return Math.exp(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiExponentialFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiExponentialFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiFloorFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiFloorFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiFloorFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.floor(((Number) result).doubleValue());
+        return Math.floor(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiFloorFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiFloorFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseCosineFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseCosineFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,12 +42,7 @@ public class PsiInverseCosineFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.acos(((Number) result).doubleValue());
+        return Math.acos(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -76,10 +69,7 @@ public class PsiInverseCosineFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiInverseCosineFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseSineFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseSineFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiInverseSineFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.asin(((Number) result).doubleValue());
+        return Math.asin(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiInverseSineFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiInverseSineFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseTangentFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiInverseTangentFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiInverseTangentFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.atan(((Number) result).doubleValue());
+        return Math.atan(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiInverseTangentFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiInverseTangentFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiLocationFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiLocationFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.bukkit.Location;
 import org.bukkit.World;
@@ -68,43 +66,13 @@ public class PsiLocationFunction extends PsiElement<Location> {
     @NotNull
     @Override
     public Location executeImpl(@Nullable Context context) {
-        Object worldResult = world.execute(context);
-
-        if (!(worldResult instanceof World))
-            throw new ExecutionException("Result of expression should be a world, but it wasn't");
-
-        Object xResult = x.execute(context);
-
-        if (!(xResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object yResult = y.execute(context);
-
-        if (!(yResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object zResult = z.execute(context);
-
-        if (!(zResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object yawResult = yaw == null ? null : yaw.execute(context);
-
-        if (yawResult != null && !(yawResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object pitchResult = pitch == null ? null : pitch.execute(context);
-
-        if (pitchResult != null && !(pitchResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
         return new Location(
-            (World) worldResult,
-            ((Number) xResult).doubleValue(),
-            ((Number) yResult).doubleValue(),
-            ((Number) zResult).doubleValue(),
-            yawResult == null ? 0 : ((Number) yawResult).floatValue(),
-            pitchResult == null ? 0 : ((Number) pitchResult).floatValue()
+                world.execute(context, World.class),
+                x.execute(context, Number.class).doubleValue(),
+                y.execute(context, Number.class).doubleValue(),
+                z.execute(context, Number.class).doubleValue(),
+                yaw == null ? 0 : yaw.execute(context, Number.class).floatValue(),
+                pitch == null ? 0 : pitch.execute(context, Number.class).floatValue()
         );
     }
 
@@ -136,23 +104,20 @@ public class PsiLocationFunction extends PsiElement<Location> {
             if (values.length < 4 || values.length > 6)
                 return null;
 
-            PsiElement<?> world = SkriptLoader.get().tryParseElement(values[0]);
-
-            if (world == null)
-                throw new ParseException("Function was unable to find an expression named " + values[0]);
+            PsiElement<?> world = SkriptLoader.get().forceParseElement(values[0]);
 
             List<PsiElement<?>> elements = new ArrayList<>(Math.min(values.length, 5));
 
             for (int i = 1; i < values.length; i++)
-                elements.add(i - 1, SkriptLoader.get().tryParseElement(values[i]));
+                elements.add(i - 1, SkriptLoader.get().forceParseElement(values[i]));
 
             return new PsiLocationFunction(
-                world,
-                elements.get(0),
-                elements.get(1),
-                elements.get(2),
-                elements.size() > 3 ? elements.get(3) : null,
-                elements.size() > 4 ? elements.get(4) : null
+                    world,
+                    elements.get(0),
+                    elements.get(1),
+                    elements.get(2),
+                    elements.size() > 3 ? elements.get(3) : null,
+                    elements.size() > 4 ? elements.get(4) : null
             );
         }
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiLogarithmFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiLogarithmFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -53,18 +51,8 @@ public class PsiLogarithmFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object valueResult = value.execute(context);
-
-        if (!(valueResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object baseResult = base == null ? null : base.execute(context);
-
-        if (baseResult != null && !(baseResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.log10(((Number) valueResult).doubleValue()) /
-            Math.log10(baseResult == null ? 10 : ((Number) baseResult).doubleValue());
+        return Math.log10(value.execute(context, Number.class).doubleValue()) /
+            Math.log10(base == null ? 10 : base.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -95,18 +83,12 @@ public class PsiLogarithmFunction extends PsiElement<Double> {
             if (values.length < 1 || values.length > 2)
                 return null;
 
-            PsiElement<?> value = SkriptLoader.get().tryParseElement(values[0]);
-
-            if (value == null)
-                throw new ParseException("Function was unable to find an expression named " + values[0]);
+            PsiElement<?> value = SkriptLoader.get().forceParseElement(values[0]);
 
             PsiElement<?> base = null;
 
             if (values.length == 2) {
-                base = SkriptLoader.get().tryParseElement(values[1]);
-
-                if (base == null)
-                    throw new ParseException("Function was unable to find an expression named " + values[1]);
+                base = SkriptLoader.get().forceParseElement(values[1]);
             }
 
             return new PsiLogarithmFunction(value, base);

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMaximumFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMaximumFunction.java
@@ -47,12 +47,7 @@ public class PsiMaximumFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object elementResult = element.execute(context);
-
-        if (!(elementResult instanceof Iterable<?>))
-            throw new ExecutionException("Result of expression should be an iterable, but it wasn't");
-
-        Iterable<?> iterable = (Iterable<?>) elementResult;
+        Iterable<?> iterable = element.execute(context, Iterable.class);
 
         double max = -Double.MAX_VALUE; //negative double max value is the actual smallest value, double min value is still positive
 
@@ -60,12 +55,7 @@ public class PsiMaximumFunction extends PsiElement<Double> {
             if (!(object instanceof PsiElement<?>))
                 throw new ExecutionException("Iterable should only contain psi elements, but it didn't");
 
-            Object numberResult = ((PsiElement) object).execute(context);
-
-            if (!(numberResult instanceof Number))
-                throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-            double value = ((Number) numberResult).doubleValue();
+            double value = ((PsiElement<?>) object).execute(context, Number.class).doubleValue();
 
             if (max < value)
                 max = value;
@@ -107,7 +97,7 @@ public class PsiMaximumFunction extends PsiElement<Double> {
             }
 
             return new PsiMaximumFunction(new PsiPrecomputedHolder<>(Arrays.stream(values)
-                    .map(string -> SkriptLoader.get().tryParseElement(string))
+                    .map(string -> SkriptLoader.get().forceParseElement(string))
                     .collect(Collectors.toList())));
         }
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMinimumFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMinimumFunction.java
@@ -47,25 +47,15 @@ public class PsiMinimumFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object elementResult = element.execute(context);
+        Iterable<?> iterable = element.execute(context, Iterable.class);
 
-        if (!(elementResult instanceof Iterable<?>))
-            throw new ExecutionException("Result of expression should be an iterable, but it wasn't");
-
-        Iterable<?> iterable = (Iterable<?>) elementResult;
-
-        double min = Double.MAX_VALUE; //negative double max value is the actual smallest value, double min value is still positive
+        double min = Double.MAX_VALUE;
 
         for (Object object : iterable) {
             if (!(object instanceof PsiElement<?>))
                 throw new ExecutionException("Iterable should only contain psi elements, but it didn't");
 
-            Object numberResult = ((PsiElement) object).execute(context);
-
-            if (!(numberResult instanceof Number))
-                throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-            double value = ((Number) numberResult).doubleValue();
+            double value = ((PsiElement<?>) object).execute(context, Number.class).doubleValue();
 
             if (min > value)
                 min = value;
@@ -107,7 +97,7 @@ public class PsiMinimumFunction extends PsiElement<Double> {
             }
 
             return new PsiMinimumFunction(new PsiPrecomputedHolder<>(Arrays.stream(values)
-                    .map(string -> SkriptLoader.get().tryParseElement(string))
+                    .map(string -> SkriptLoader.get().forceParseElement(string))
                     .collect(Collectors.toList())));
         }
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiModuloFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiModuloFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -46,17 +44,7 @@ public class PsiModuloFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object aResult = a.execute(context);
-
-        if (!(aResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object bResult = b.execute(context);
-
-        if (!(bResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return ((Number) aResult).doubleValue() % ((Number) bResult).doubleValue();
+        return a.execute(context, Number.class).doubleValue() % b.execute(context, Number.class).doubleValue();
     }
 
     /**
@@ -87,15 +75,8 @@ public class PsiModuloFunction extends PsiElement<Double> {
             if (values.length != 2)
                 return null;
 
-            PsiElement<?> a = SkriptLoader.get().tryParseElement(values[0]);
-
-            if (a == null)
-                throw new ParseException("Function was unable to find an expression named " + values[0]);
-
-            PsiElement<?> b = SkriptLoader.get().tryParseElement(values[1]);
-
-            if (b == null)
-                throw new ParseException("Function was unable to find an expression named " + values[1]);
+            PsiElement<?> a = SkriptLoader.get().forceParseElement(values[0]);
+            PsiElement<?> b = SkriptLoader.get().forceParseElement(values[1]);
 
             return new PsiModuloFunction(a, b);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiNaturalLogarithmFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiNaturalLogarithmFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiNaturalLogarithmFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.log(((Number) result).doubleValue());
+        return Math.log(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiNaturalLogarithmFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiNaturalLogarithmFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiProductFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiProductFunction.java
@@ -47,25 +47,15 @@ public class PsiProductFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object elementResult = element.execute(context);
+        Iterable<?> iterable = element.execute(context, Iterable.class);
 
-        if (!(elementResult instanceof Iterable<?>))
-            throw new ExecutionException("Result of expression should be an iterable, but it wasn't");
-
-        Iterable<?> iterable = (Iterable<?>) elementResult;
-
-        double result = 1; //negative double max value is the actual smallest value, double min value is still positive
+        double result = 1;
 
         for (Object object : iterable) {
             if (!(object instanceof PsiElement<?>))
                 throw new ExecutionException("Iterable should only contain psi elements, but it didn't");
 
-            Object numberResult = ((PsiElement) object).execute(context);
-
-            if (!(numberResult instanceof Number))
-                throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-            result *= ((Number) numberResult).doubleValue();
+            result *= ((PsiElement<?>) object).execute(context, Number.class).doubleValue();
         }
 
         return result;
@@ -104,7 +94,7 @@ public class PsiProductFunction extends PsiElement<Double> {
             }
 
             return new PsiProductFunction(new PsiPrecomputedHolder<>(Arrays.stream(values)
-                    .map(string -> SkriptLoader.get().tryParseElement(string))
+                    .map(string -> SkriptLoader.get().forceParseElement(string))
                     .collect(Collectors.toList())));
         }
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiRoundFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiRoundFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiRoundFunction extends PsiElement<Long> {
     @NotNull
     @Override
     protected Long executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.round(((Number) result).doubleValue());
+        return Math.round(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiRoundFunction extends PsiElement<Long> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiRoundFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSineFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSineFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiSineFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.sin(((Number) result).doubleValue());
+        return Math.sin(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiSineFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiSineFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSquareRootFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSquareRootFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiSquareRootFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.sqrt(((Number) result).doubleValue());
+        return Math.sqrt(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiSquareRootFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiSquareRootFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSumFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiSumFunction.java
@@ -47,25 +47,15 @@ public class PsiSumFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object elementResult = element.execute(context);
+        Iterable<?> iterable = element.execute(context, Iterable.class);
 
-        if (!(elementResult instanceof Iterable<?>))
-            throw new ExecutionException("Result of expression should be an iterable, but it wasn't");
-
-        Iterable<?> iterable = (Iterable<?>) elementResult;
-
-        double result = 0; //negative double max value is the actual smallest value, double min value is still positive
+        double result = 0;
 
         for (Object object : iterable) {
             if (!(object instanceof PsiElement<?>))
                 throw new ExecutionException("Iterable should only contain psi elements, but it didn't");
 
-            Object numberResult = ((PsiElement) object).execute(context);
-
-            if (!(numberResult instanceof Number))
-                throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-            result += ((Number) numberResult).doubleValue();
+            result += ((PsiElement<?>) object).execute(context, Number.class).doubleValue();
         }
 
         return result;
@@ -104,7 +94,7 @@ public class PsiSumFunction extends PsiElement<Double> {
             }
             
             return new PsiSumFunction(new PsiPrecomputedHolder<>(Arrays.stream(values)
-                    .map(string -> SkriptLoader.get().tryParseElement(string))
+                    .map(string -> SkriptLoader.get().forceParseElement(string))
                     .collect(Collectors.toList())));
         }
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiTangentFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiTangentFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -45,12 +43,7 @@ public class PsiTangentFunction extends PsiElement<Double> {
     @NotNull
     @Override
     protected Double executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return Math.tan(((Number) result).doubleValue());
+        return Math.tan(parameter.execute(context, Number.class).doubleValue());
     }
 
     /**
@@ -77,10 +70,7 @@ public class PsiTangentFunction extends PsiElement<Double> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiTangentFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiVectorFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiVectorFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -49,23 +47,11 @@ public class PsiVectorFunction extends PsiElement<Vector> {
     @NotNull
     @Override
     protected Vector executeImpl(@Nullable Context context) {
-        Object xResult = x.execute(context);
+        Number xResult = x.execute(context, Number.class);
+        Number yResult = y.execute(context, Number.class);
+        Number zResult = z.execute(context, Number.class);
 
-        if (!(xResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object yResult = y.execute(context);
-
-        if (!(yResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        Object zResult = z.execute(context);
-
-        if (!(zResult instanceof Number))
-            throw new ExecutionException("Result of expression should be a number, but it wasn't");
-
-        return new Vector(((Number) xResult).doubleValue(), ((Number) yResult).doubleValue(),
-            ((Number) zResult).doubleValue());
+        return new Vector(xResult.doubleValue(), yResult.doubleValue(), zResult.doubleValue());
     }
 
     /**
@@ -96,20 +82,9 @@ public class PsiVectorFunction extends PsiElement<Vector> {
             if (values.length != 3)
                 return null;
 
-            PsiElement<?> x = SkriptLoader.get().tryParseElement(values[0]);
-
-            if (x == null)
-                throw new ParseException("Function was unable to find an expression named " + values[0]);
-
-            PsiElement<?> y = SkriptLoader.get().tryParseElement(values[1]);
-
-            if (y == null)
-                throw new ParseException("Function was unable to find an expression named " + values[1]);
-
-            PsiElement<?> z = SkriptLoader.get().tryParseElement(values[2]);
-
-            if (z == null)
-                throw new ParseException("Function was unable to find an expression named " + values[2]);
+            PsiElement<?> x = SkriptLoader.get().forceParseElement(values[0]);
+            PsiElement<?> y = SkriptLoader.get().forceParseElement(values[1]);
+            PsiElement<?> z = SkriptLoader.get().forceParseElement(values[2]);
 
             return new PsiVectorFunction(x, y, z);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiWorldFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiWorldFunction.java
@@ -3,8 +3,6 @@ package com.github.stefvanschie.quickskript.psi.function;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import com.github.stefvanschie.quickskript.util.TextMessage;
 import org.bukkit.Bukkit;
@@ -43,12 +41,7 @@ public class PsiWorldFunction extends PsiElement<World> {
      */
     @Override
     public World executeImpl(@Nullable Context context) {
-        Object result = parameter.execute(context);
-
-        if (!(result instanceof TextMessage))
-            throw new ExecutionException("Result of expression should be a text message, but it wasn't");
-
-        return Bukkit.getWorld(((TextMessage) result).construct());
+        return Bukkit.getWorld(parameter.execute(context, TextMessage.class).construct());
     }
 
     /**
@@ -75,10 +68,7 @@ public class PsiWorldFunction extends PsiElement<World> {
                 return null;
 
             String expression = matcher.group(1);
-            PsiElement<?> element = SkriptLoader.get().tryParseElement(expression);
-
-            if (element == null)
-                throw new ParseException("Function was unable to find an expression named " + expression);
+            PsiElement<?> element = SkriptLoader.get().forceParseElement(expression);
 
             return new PsiWorldFunction(element);
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptLoader.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptLoader.java
@@ -9,6 +9,7 @@ import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.psi.effect.PsiCancelEventEffect;
 import com.github.stefvanschie.quickskript.psi.effect.PsiMessageEffect;
+import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.psi.expression.PsiConsoleSenderExpression;
 import com.github.stefvanschie.quickskript.psi.expression.PsiParseExpression;
 import com.github.stefvanschie.quickskript.psi.function.*;
@@ -130,7 +131,8 @@ public class SkriptLoader implements AutoCloseable {
 
 
     /**
-     * Parses text into psi elements. Returns null if no element was found.
+     * Parses text into psi elements.
+     * Returns null if no element was found.
      *
      * @param input the text to be parsed
      * @return the parsed psi element, or null if none were found
@@ -152,7 +154,26 @@ public class SkriptLoader implements AutoCloseable {
     }
 
     /**
+     * Parses text into psi elements.
+     * Throws a {@link ParseException} if no element was found.
+     *
+     * @param input the text to be parsed
+     * @return the parsed psi element
+     * @since 0.1.0
+     */
+    @NotNull
+    public PsiElement<?> forceParseElement(@NotNull String input) {
+        PsiElement<?> result = tryParseElement(input);
+        if (result != null)
+            return result;
+
+        throw new ParseException("Unable to find an expression named: " + input);
+    }
+
+
+    /**
      * Returns a converter based on the specified name.
+     * Returns null if no converter was found.
      *
      * @param name the name of the converter
      * @return the converter
@@ -160,9 +181,28 @@ public class SkriptLoader implements AutoCloseable {
      */
     @Nullable
     @Contract(pure = true)
-    public PsiConverter<?> getConverter(@NotNull String name) {
+    public PsiConverter<?> tryGetConverter(@NotNull String name) {
         return converters.get(name);
     }
+
+    /**
+     * Returns a converter based on the specified name.
+     * Throws a {@link ParseException} if no converter was found.
+     *
+     * @param name the name of the converter
+     * @return the converter
+     * @since 0.1.0
+     */
+    @NotNull
+    @Contract(pure = true)
+    public PsiConverter<?> forceGetConverter(@NotNull String name) {
+        PsiConverter<?> result = tryGetConverter(name);
+        if (result != null)
+            return result;
+
+        throw new ParseException("Unable to find a converter named: " + name);
+    }
+
 
     /**
      * Parses the inputted text and returns whether an event was registered.


### PR DESCRIPTION
This change greatly reduces the amount of boilerplate code which has to be written.
Also, the `ParseException` and the `ExecutionException` are being caught now.