### PR TITLE
Exception message, TextPart changes

### DIFF
--- a/src/main/java/com/github/stefvanschie/quickskript/QuickSkript.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/QuickSkript.java
@@ -63,14 +63,9 @@ public class QuickSkript extends JavaPlugin {
 
                 try {
                     skript.registerCommands();
-                } catch (ParseException e) {
-                    getLogger().log(Level.SEVERE, "Error while parsing commands of skript named " + skriptName + " at line " + e.getLineNumber(), e);
-                }
-
-                try {
                     skript.registerEventExecutors();
                 } catch (ParseException e) {
-                    getLogger().log(Level.SEVERE, "Error while parsing event executors of skript named " + skriptName + " at line " + e.getLineNumber(), e);
+                    getLogger().log(Level.SEVERE, "Error while parsing:" + e.getExtraInfo(skriptName), e);
                 }
             }
         }

--- a/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFile.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFile.java
@@ -17,7 +17,7 @@ import java.util.List;
  *
  * @since 0.1.0
  */
-public class SkriptFile extends SkriptFileSection {
+public class SkriptFile {
 
     /**
      * Loads a skript file from a given file
@@ -105,8 +105,6 @@ public class SkriptFile extends SkriptFileSection {
      * @param section the backing section of this file
      */
     private SkriptFile(@NotNull SkriptFileSection section) {
-        super(section.getText(), 0);
-
         this.section = section;
     }
 

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/exception/ParseException.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/exception/ParseException.java
@@ -1,5 +1,9 @@
 package com.github.stefvanschie.quickskript.psi.exception;
 
+import com.github.stefvanschie.quickskript.file.SkriptFile;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * An exception thrown when the parser was unable to execute properly.
  *
@@ -8,9 +12,9 @@ package com.github.stefvanschie.quickskript.psi.exception;
 public class ParseException extends RuntimeException {
 
     /**
-     * Stores the line number this error occurred at
+     * Stores the line number this exception occurred at
      */
-    private int lineNumber;
+    private final int lineNumber;
 
     /**
      * {@inheritDoc}
@@ -22,12 +26,17 @@ public class ParseException extends RuntimeException {
     }
 
     /**
-     * Gets the line number this error occured at
+     * Constructs and returns text containing extra information regarding this exception.
+     * A line separator is inserted at the start for convenience.
+     * This method should always be used when the exception gets handled.
      *
-     * @return the line number
-     * @since 0.1.0
+     * @param fileName the name of the {@link SkriptFile}
+     * in which the code which caused this exception is
+     * @return extra information regarding this exception
      */
-    public int getLineNumber() {
-        return lineNumber;
+    @NotNull
+    @Contract(pure = true)
+    public String getExtraInfo(String fileName) {
+        return System.lineSeparator() + "Skript file: " + fileName + " | Line number: " + lineNumber;
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/exception/ParseException.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/exception/ParseException.java
@@ -33,10 +33,11 @@ public class ParseException extends RuntimeException {
      * @param fileName the name of the {@link SkriptFile}
      * in which the code which caused this exception is
      * @return extra information regarding this exception
+     * @since 0.1.0
      */
     @NotNull
     @Contract(pure = true)
-    public String getExtraInfo(String fileName) {
+    public String getExtraInfo(@NotNull String fileName) {
         return System.lineSeparator() + "Skript file: " + fileName + " | Line number: " + lineNumber;
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMaximumFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiMaximumFunction.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Returns the highest value from a given collection of numbers

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
@@ -71,7 +71,8 @@ public class SkriptCommandExecutor implements CommandExecutor {
         try {
             elements.forEach(element -> element.execute(context));
         } catch (ExecutionException e) {
-            QuickSkript.getInstance().getLogger().log(Level.SEVERE, "Error while executing skript named " + skript.getName(), e);
+            QuickSkript.getInstance().getLogger().log(Level.SEVERE, "Error while executing skript:" +
+                    e.getExtraInfo(skript.getName()), e);
         }
 
         return true;

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
@@ -56,7 +56,8 @@ public class SkriptEventExecutor {
         try {
             elements.forEach(element -> element.execute(context));
         } catch (ExecutionException e) {
-            QuickSkript.getInstance().getLogger().log(Level.SEVERE, "Error while executing skript named " + skript.getName(), e);
+            QuickSkript.getInstance().getLogger().log(Level.SEVERE, "Error while executing:" +
+                    e.getExtraInfo(skript.getName()), e);
         }
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/util/Text.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/util/Text.java
@@ -39,10 +39,7 @@ public final class Text {
     public String construct() {
         StringBuilder message = new StringBuilder();
 
-        parts.forEach(part -> {
-            if (part instanceof TextString)
-                message.append(((TextString) part).getText());
-        });
+        parts.forEach(part -> part.append(message));
 
         return message.toString();
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/util/TextPart.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/util/TextPart.java
@@ -5,4 +5,14 @@ package com.github.stefvanschie.quickskript.util;
  *
  * @since 0.1.0
  */
-interface TextPart {}
+interface TextPart {
+
+    /**
+     * Adds this {@link TextPart} instance to the end of
+     * the specified {@link StringBuilder}.
+     *
+     * @param builder the builder to append to
+     * @since 0.1.0
+     */
+    void append(StringBuilder builder);
+}

--- a/src/main/java/com/github/stefvanschie/quickskript/util/TextString.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/util/TextString.java
@@ -1,6 +1,5 @@
 package com.github.stefvanschie.quickskript.util;
 
-import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -27,14 +26,10 @@ public class TextString implements TextPart {
     }
 
     /**
-     * Returns the text message
-     *
-     * @return the text
-     * @since 0.1.0
+     * {@inheritDoc}
      */
-    @NotNull
-    @Contract(pure = true)
-    public String getText() {
-        return text;
+    @Override
+    public void append(@NotNull StringBuilder builder) {
+        builder.append(text);
     }
 }

--- a/src/test/java/com/github/stefvanschie/quickskript/parsing/SkriptFileParseTest.java
+++ b/src/test/java/com/github/stefvanschie/quickskript/parsing/SkriptFileParseTest.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.parsing;
 
 import com.github.stefvanschie.quickskript.TestClassBase;
 import com.github.stefvanschie.quickskript.file.SkriptFile;
+import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.Skript;
 import org.junit.jupiter.api.Test;
 
@@ -9,8 +10,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Objects;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A test which asserts that all specified skript files
@@ -24,13 +23,15 @@ class SkriptFileParseTest extends TestClassBase {
         File directory = new File(Objects.requireNonNull(resource).getPath());
 
         for (File file : Objects.requireNonNull(directory.listFiles())) {
-            Skript skript = new Skript(SkriptFile.getName(file), SkriptFile.load(file));
+            String name = SkriptFile.getName(file);
+            Skript skript = new Skript(name, SkriptFile.load(file));
 
-            assertDoesNotThrow(skript::registerCommands,
-                    "Error while parsing commands of skript file: " + file.getName());
-
-            assertDoesNotThrow(skript::registerEventExecutors,
-                    "Error while parsing event executors of skript file: " + file.getName());
+            try {
+                skript.registerCommands();
+                skript.registerEventExecutors();
+            } catch (ParseException e) {
+                throw new AssertionError("Error while parsing:" + e.getExtraInfo(name), e);
+            }
         }
     }
 }


### PR DESCRIPTION
Changes:
 - Addition of a `ParseException#getExtraInfo` method: a method used to give extra information regarding the exception when handling it.
 - Addition of a `TextPart#append(StringBuilder)` method: with this method in place, there is no need to do a bunch of `instanceof` checks inside `Text#construct`.
 - `SkriptFile` no longer extends `SkriptFileSection`. I have already made this change previously. I assumed that you undid it by mistake, in case that is not true, I apologize.