### PR TITLE
Execution time profiler

### DIFF
--- a/src/main/java/com/github/stefvanschie/quickskript/QuickSkript.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/QuickSkript.java
@@ -4,8 +4,12 @@ import com.github.stefvanschie.quickskript.file.SkriptFile;
 import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.Skript;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
+import com.github.stefvanschie.quickskript.skript.profiler.EmptySkriptProfiler;
+import com.github.stefvanschie.quickskript.skript.profiler.SimpleSkriptProfiler;
+import com.github.stefvanschie.quickskript.skript.profiler.SkriptProfiler;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,11 +34,31 @@ public class QuickSkript extends JavaPlugin {
     }
 
     /**
+     * Since plugins are singletons by design in Bukkit, this method
+     * aims to be a short and efficient way of getting the plugin instance.
+     *
+     * @return the current instance of the plugin or null if the plugin is not enabled
+     * @since 0.1.0
+     */
+    @Contract(pure = true)
+    public static QuickSkript getInstance() {
+        return instance;
+    }
+
+
+    /**
+     * The profiler to use throughout this plugin
+     */
+    @NotNull
+    private SkriptProfiler profiler = new EmptySkriptProfiler();
+
+    /**
      * {@inheritDoc}
      */
     @Override
     public void onEnable() {
         instance = this;
+        profiler = new SimpleSkriptProfiler();
 
         try (SkriptLoader ignored = new SkriptLoader()) {
 
@@ -81,14 +105,23 @@ public class QuickSkript extends JavaPlugin {
 
 
     /**
-     * Since plugins are singletons by design in Bukkit, this method
-     * aims to be a short and efficient way of getting the plugin instance.
+     * Gets the active profiler instance.
      *
-     * @return the current instance of the plugin or null if the plugin is not enabled
+     * @return the current profiler
      * @since 0.1.0
      */
-    @Contract(pure = true)
-    public static QuickSkript getInstance() {
-        return instance;
+    @NotNull
+    public SkriptProfiler getSkriptProfiler() {
+        return profiler;
+    }
+
+    /**
+     * Sets the active profiler instance.
+     *
+     * @param profiler the new profile to use
+     * @since 0.1.0
+     */
+    public void setSkriptProfiler(@NotNull SkriptProfiler profiler) {
+        this.profiler = profiler;
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/EmptySkriptProfiler.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/EmptySkriptProfiler.java
@@ -1,0 +1,41 @@
+package com.github.stefvanschie.quickskript.skript.profiler;
+
+import com.github.stefvanschie.quickskript.context.Context;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A profiler which does not store any data.
+ *
+ * @since 0.1.0
+ */
+public class EmptySkriptProfiler extends SkriptProfiler {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onTimeMeasured(@NotNull Context context, @NotNull String identifier, long elapsedTime) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Nullable
+    @Override
+    public TimingEntry getTimingEntry(@NotNull Class<? extends Context> contextType, @NotNull String identifier) {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NotNull
+    @Override
+    public Collection<String> getTimingEntryIdentifiers(@NotNull Class<? extends Context> contextType) {
+        return Collections.emptySet();
+    }
+}

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SimpleSkriptProfiler.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SimpleSkriptProfiler.java
@@ -1,0 +1,93 @@
+package com.github.stefvanschie.quickskript.skript.profiler;
+
+import com.github.stefvanschie.quickskript.context.Context;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * A simple profiler: it just implements the interface.
+ * Should be good enough in most cases.
+ *
+ * @since 0.1.0
+ */
+public class SimpleSkriptProfiler extends SkriptProfiler {
+
+    /**
+     * The storage of the profiler entries
+     */
+    private final Map<Class<? extends Context>, Map<String, SimpleEntry>> storage = new HashMap<>();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onTimeMeasured(@NotNull Context context, @NotNull String identifier, long elapsedTime) {
+        storage.computeIfAbsent(context.getClass(), type -> new HashMap<>())
+                .computeIfAbsent(identifier, id -> new SimpleEntry())
+                .add(elapsedTime);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Nullable
+    @Override
+    public TimingEntry getTimingEntry(@NotNull Class<? extends Context> contextType, @NotNull String identifier) {
+        Map<String, SimpleEntry> entries = storage.get(contextType);
+        return entries == null ? null : entries.get(identifier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NotNull
+    @Override
+    public Collection<String> getTimingEntryIdentifiers(@NotNull Class<? extends Context> contextType) {
+        Map<String, SimpleEntry> entries = storage.get(contextType);
+        return entries == null ? Collections.emptySet() : entries.keySet();
+    }
+
+
+    /**
+     * A simple implementation of a profiler entry.
+     */
+    private static class SimpleEntry implements TimingEntry {
+        /**
+         * The number of times the elapsed time was recorded
+         */
+        private int count;
+
+        /**
+         * The sum of the elapsed times
+         */
+        private long totalTime;
+
+        /**
+         * Stores one more execution of the entry point associated with this entry.
+         *
+         * @param elapsedTime the time which elapsed during execution this time
+         */
+        void add(long elapsedTime) {
+            count++;
+            totalTime += elapsedTime;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int getCalledCount() {
+            return count;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public long getTotalElapsedTime() {
+            return totalTime;
+        }
+    }
+}

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SkriptProfiler.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SkriptProfiler.java
@@ -1,0 +1,87 @@
+package com.github.stefvanschie.quickskript.skript.profiler;
+
+import com.github.stefvanschie.quickskript.context.Context;
+import com.github.stefvanschie.quickskript.skript.Skript;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+
+/**
+ * A profiler capable of measuring the execution times of each Skript entry-point.
+ *
+ * @since 0.1.0
+ */
+public abstract class SkriptProfiler {
+
+    /**
+     * Creates an identifier for an entry point.
+     *
+     * @param skript the container of the entry point
+     * @param lineNumber the line number of entry point
+     * @return the identifier created for the entry point
+     * @since 0.1.0
+     */
+    @NotNull
+    @Contract(pure = true)
+    public static String getIdentifier(@NotNull Skript skript, int lineNumber) {
+        return skript.getName() + "#" + lineNumber;
+    }
+
+    /**
+     * Called whenever the code inside an entry point was (successfully) executed.
+     *
+     * @param context the context of the entry point
+     * @param identifier the identifier of the entry point
+     * @param elapsedTime the time it took to execute the code in the entry point
+     * @since 0.1.0
+     */
+    public abstract void onTimeMeasured(@NotNull Context context, @NotNull String identifier, long elapsedTime);
+
+    /**
+     * Gets the entry associated with the specified entry point.
+     *
+     * @param contextType the type of the entry we want to retrieve
+     * @param identifier the identifier of the entry point
+     * @return the entry associated with the parameters, if any
+     * @since 0.1.0
+     */
+    @Nullable
+    public abstract TimingEntry getTimingEntry(@NotNull Class<? extends Context> contextType, @NotNull String identifier);
+
+    /**
+     * Gets all entry identifiers which have entries associated with them.
+     *
+     * @param contextType the type of the entry identifiers we want to list
+     * @return the entry identifiers
+     * @since 0.1.0
+     */
+    @NotNull
+    public abstract Collection<String> getTimingEntryIdentifiers(@NotNull Class<? extends Context> contextType);
+
+
+    /**
+     * A profiler empty which stores the timings associated with an entry point.
+     *
+     * @since 0.1.0
+     */
+    public interface TimingEntry {
+
+        /**
+         * Gets the number of times the elapsed time was recorded.
+         *
+         * @return the number of times the elapsed time was recorded.
+         * @since 0.1.0
+         */
+        int getCalledCount();
+
+        /**
+         * Gets the sum of all recorded elapsed times in nanoseconds.
+         *
+         * @return the elapsed time sum in nanoseconds.
+         * @since 0.1.0
+         */
+        long getTotalElapsedTime();
+    }
+}


### PR DESCRIPTION
This PR adds a profiler which currently only measures the time it took to finish executing the Skript code entry points (event listeners, command executors). This recorded data can not be accessed at the moment without external plugins using the APIs.