### PR TITLE
Update execution time profiler identifier

### DIFF
--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
@@ -94,7 +94,7 @@ public class SkriptCommandExecutor implements CommandExecutor {
             return true;
         }
 
-        QuickSkript.getInstance().getSkriptProfiler().onTimeMeasured(context,
+        QuickSkript.getInstance().getSkriptProfiler().onTimeMeasured(CommandContext.class,
                 profilerIdentifier, System.nanoTime() - startTime);
         return true;
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
@@ -34,7 +34,7 @@ public class SkriptCommandExecutor implements CommandExecutor {
      * The identifier of this instance to use with the {@link SkriptProfiler}
      */
     @NotNull
-    private final String profilerIdentifier;
+    private final SkriptProfiler.Identifier profilerIdentifier;
 
     /**
      * A list of elements that should get executed
@@ -59,7 +59,7 @@ public class SkriptCommandExecutor implements CommandExecutor {
      */
     SkriptCommandExecutor(@NotNull Skript skript, @NotNull SkriptFileSection section, @Nullable ExecutionTarget executionTarget) {
         this.skript = skript;
-        profilerIdentifier = SkriptProfiler.getIdentifier(skript, section.getLineNumber());
+        profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
         this.executionTarget = executionTarget;
 
         elements = section.getNodes().stream()

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
@@ -30,7 +30,7 @@ public class SkriptEventExecutor {
      * The identifier of this instance to use with the {@link SkriptProfiler}
      */
     @NotNull
-    private final String profilerIdentifier;
+    private final SkriptProfiler.Identifier profilerIdentifier;
 
     /**
      * A list of elements that should get executed
@@ -47,7 +47,7 @@ public class SkriptEventExecutor {
      */
     SkriptEventExecutor(@NotNull Skript skript, @NotNull SkriptFileSection section) {
         this.skript = skript;
-        profilerIdentifier = SkriptProfiler.getIdentifier(skript, section.getLineNumber());
+        profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
 
         elements = section.getNodes().stream()
                 .map(node -> SkriptLoader.get().forceParseElement(node.getText(), node.getLineNumber()))

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
@@ -80,7 +80,7 @@ public class SkriptEventExecutor {
             return;
         }
 
-        QuickSkript.getInstance().getSkriptProfiler().onTimeMeasured(context,
+        QuickSkript.getInstance().getSkriptProfiler().onTimeMeasured(EventContext.class,
                 profilerIdentifier, System.nanoTime() - startTime);
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/EmptySkriptProfiler.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/EmptySkriptProfiler.java
@@ -18,7 +18,7 @@ public class EmptySkriptProfiler extends SkriptProfiler {
      * {@inheritDoc}
      */
     @Override
-    public void onTimeMeasured(@NotNull Context context, @NotNull Identifier identifier, long elapsedTime) {
+    public void onTimeMeasured(@NotNull Class<? extends Context> contextType, @NotNull Identifier identifier, long elapsedTime) {
     }
 
     /**

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/EmptySkriptProfiler.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/EmptySkriptProfiler.java
@@ -18,7 +18,7 @@ public class EmptySkriptProfiler extends SkriptProfiler {
      * {@inheritDoc}
      */
     @Override
-    public void onTimeMeasured(@NotNull Context context, @NotNull String identifier, long elapsedTime) {
+    public void onTimeMeasured(@NotNull Context context, @NotNull Identifier identifier, long elapsedTime) {
     }
 
     /**
@@ -26,7 +26,7 @@ public class EmptySkriptProfiler extends SkriptProfiler {
      */
     @Nullable
     @Override
-    public TimingEntry getTimingEntry(@NotNull Class<? extends Context> contextType, @NotNull String identifier) {
+    public TimingEntry getTimingEntry(@NotNull Class<? extends Context> contextType, @NotNull Identifier identifier) {
         return null;
     }
 
@@ -35,7 +35,7 @@ public class EmptySkriptProfiler extends SkriptProfiler {
      */
     @NotNull
     @Override
-    public Collection<String> getTimingEntryIdentifiers(@NotNull Class<? extends Context> contextType) {
+    public Collection<Identifier> getTimingEntryIdentifiers(@NotNull Class<? extends Context> contextType) {
         return Collections.emptySet();
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SimpleSkriptProfiler.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SimpleSkriptProfiler.java
@@ -17,14 +17,14 @@ public class SimpleSkriptProfiler extends SkriptProfiler {
     /**
      * The storage of the profiler entries
      */
-    private final Map<Class<? extends Context>, Map<Identifier, SimpleEntry>> storage = new HashMap<>();
+    private final Map<Class<? extends Context>, Map<Identifier, SimpleEntry>> storage = new IdentityHashMap<>();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void onTimeMeasured(@NotNull Context context, @NotNull Identifier identifier, long elapsedTime) {
-        storage.computeIfAbsent(context.getClass(), type -> new HashMap<>())
+    public void onTimeMeasured(@NotNull Class<? extends Context> contextType, @NotNull Identifier identifier, long elapsedTime) {
+        storage.computeIfAbsent(contextType, type -> new HashMap<>())
                 .computeIfAbsent(identifier, id -> new SimpleEntry())
                 .add(elapsedTime);
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SimpleSkriptProfiler.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SimpleSkriptProfiler.java
@@ -17,13 +17,13 @@ public class SimpleSkriptProfiler extends SkriptProfiler {
     /**
      * The storage of the profiler entries
      */
-    private final Map<Class<? extends Context>, Map<String, SimpleEntry>> storage = new HashMap<>();
+    private final Map<Class<? extends Context>, Map<Identifier, SimpleEntry>> storage = new HashMap<>();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void onTimeMeasured(@NotNull Context context, @NotNull String identifier, long elapsedTime) {
+    public void onTimeMeasured(@NotNull Context context, @NotNull Identifier identifier, long elapsedTime) {
         storage.computeIfAbsent(context.getClass(), type -> new HashMap<>())
                 .computeIfAbsent(identifier, id -> new SimpleEntry())
                 .add(elapsedTime);
@@ -34,8 +34,8 @@ public class SimpleSkriptProfiler extends SkriptProfiler {
      */
     @Nullable
     @Override
-    public TimingEntry getTimingEntry(@NotNull Class<? extends Context> contextType, @NotNull String identifier) {
-        Map<String, SimpleEntry> entries = storage.get(contextType);
+    public TimingEntry getTimingEntry(@NotNull Class<? extends Context> contextType, @NotNull Identifier identifier) {
+        Map<Identifier, SimpleEntry> entries = storage.get(contextType);
         return entries == null ? null : entries.get(identifier);
     }
 
@@ -44,8 +44,8 @@ public class SimpleSkriptProfiler extends SkriptProfiler {
      */
     @NotNull
     @Override
-    public Collection<String> getTimingEntryIdentifiers(@NotNull Class<? extends Context> contextType) {
-        Map<String, SimpleEntry> entries = storage.get(contextType);
+    public Collection<Identifier> getTimingEntryIdentifiers(@NotNull Class<? extends Context> contextType) {
+        Map<Identifier, SimpleEntry> entries = storage.get(contextType);
         return entries == null ? Collections.emptySet() : entries.keySet();
     }
 
@@ -54,6 +54,7 @@ public class SimpleSkriptProfiler extends SkriptProfiler {
      * A simple implementation of a profiler entry.
      */
     private static class SimpleEntry implements TimingEntry {
+
         /**
          * The number of times the elapsed time was recorded
          */

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SkriptProfiler.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SkriptProfiler.java
@@ -18,12 +18,12 @@ public abstract class SkriptProfiler {
     /**
      * Called whenever the code inside an entry point was (successfully) executed.
      *
-     * @param context the context of the entry point
+     * @param contextType the type of context of the entry point
      * @param identifier the identifier of the entry point
      * @param elapsedTime the time in nanoseconds it took to execute the code in the entry point
      * @since 0.1.0
      */
-    public abstract void onTimeMeasured(@NotNull Context context, @NotNull Identifier identifier, long elapsedTime);
+    public abstract void onTimeMeasured(@NotNull Class<? extends Context> contextType, @NotNull Identifier identifier, long elapsedTime);
 
     /**
      * Gets the entry associated with the specified entry point.

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SkriptProfiler.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/profiler/SkriptProfiler.java
@@ -2,11 +2,11 @@ package com.github.stefvanschie.quickskript.skript.profiler;
 
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.skript.Skript;
-import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * A profiler capable of measuring the execution times of each Skript entry-point.
@@ -16,28 +16,14 @@ import java.util.Collection;
 public abstract class SkriptProfiler {
 
     /**
-     * Creates an identifier for an entry point.
-     *
-     * @param skript the container of the entry point
-     * @param lineNumber the line number of entry point
-     * @return the identifier created for the entry point
-     * @since 0.1.0
-     */
-    @NotNull
-    @Contract(pure = true)
-    public static String getIdentifier(@NotNull Skript skript, int lineNumber) {
-        return skript.getName() + "#" + lineNumber;
-    }
-
-    /**
      * Called whenever the code inside an entry point was (successfully) executed.
      *
      * @param context the context of the entry point
      * @param identifier the identifier of the entry point
-     * @param elapsedTime the time it took to execute the code in the entry point
+     * @param elapsedTime the time in nanoseconds it took to execute the code in the entry point
      * @since 0.1.0
      */
-    public abstract void onTimeMeasured(@NotNull Context context, @NotNull String identifier, long elapsedTime);
+    public abstract void onTimeMeasured(@NotNull Context context, @NotNull Identifier identifier, long elapsedTime);
 
     /**
      * Gets the entry associated with the specified entry point.
@@ -48,7 +34,7 @@ public abstract class SkriptProfiler {
      * @since 0.1.0
      */
     @Nullable
-    public abstract TimingEntry getTimingEntry(@NotNull Class<? extends Context> contextType, @NotNull String identifier);
+    public abstract TimingEntry getTimingEntry(@NotNull Class<? extends Context> contextType, @NotNull Identifier identifier);
 
     /**
      * Gets all entry identifiers which have entries associated with them.
@@ -58,7 +44,7 @@ public abstract class SkriptProfiler {
      * @since 0.1.0
      */
     @NotNull
-    public abstract Collection<String> getTimingEntryIdentifiers(@NotNull Class<? extends Context> contextType);
+    public abstract Collection<Identifier> getTimingEntryIdentifiers(@NotNull Class<? extends Context> contextType);
 
 
     /**
@@ -71,7 +57,7 @@ public abstract class SkriptProfiler {
         /**
          * Gets the number of times the elapsed time was recorded.
          *
-         * @return the number of times the elapsed time was recorded.
+         * @return the number of times the elapsed time was recorded
          * @since 0.1.0
          */
         int getCalledCount();
@@ -79,9 +65,74 @@ public abstract class SkriptProfiler {
         /**
          * Gets the sum of all recorded elapsed times in nanoseconds.
          *
-         * @return the elapsed time sum in nanoseconds.
+         * @return the elapsed time sum in nanoseconds
          * @since 0.1.0
          */
         long getTotalElapsedTime();
+    }
+
+    /**
+     * An identifier which is given to each Skript code entry point.
+     * Two identifiers are viewed as equal if they both point to the
+     * same line number of the same {@link Skript} instance.
+     *
+     * @since 0.1.0
+     */
+    public static class Identifier {
+
+        /**
+         * The container of the entry point.
+         */
+        @NotNull
+        private final Skript skript;
+
+        /**
+         * The location of the entry point.
+         */
+        private final int lineNumber;
+
+        /**
+         * Creates a new instance for the specified entry point.
+         *
+         * @param skript the container of the entry point
+         * @param lineNumber the location of the entry point
+         * @since 0.1.0
+         */
+        public Identifier(@NotNull Skript skript, int lineNumber) {
+            this.skript = skript;
+            this.lineNumber = lineNumber;
+        }
+
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean equals(Object other) {
+            if (other == this)
+                return true;
+
+            if (!(other instanceof Identifier))
+                return false;
+
+            Identifier id = (Identifier) other;
+            return id.skript == skript && id.lineNumber == lineNumber;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int hashCode() {
+            return Objects.hash(skript, lineNumber);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String toString() {
+            return skript.getName() + ":" + lineNumber;
+        }
     }
 }


### PR DESCRIPTION
On second thought, the `String` based profiler identifier was a very bad idea. This "fixes" this "issue".

The 2nd commit contains some minor improvements:
 - No longer require an instance of `? extends Context` to be passed: the parameter now takes `Class<? extends Context>` instead.
 - Use an identity map for storing `Class<? extends Context>` instances.