### PR TITLE
Update to Java 11, implement sections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -105,6 +105,18 @@
                         </configuration>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                        <version>7.0-beta</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm-commons</artifactId>
+                        <version>7.0-beta</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <properties>
         <url>https://github.com/stefvanschie/QuickSkript</url>
         <package>${project.groupId}.${project.artifactId}</package>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/com/github/stefvanschie/quickskript/QuickSkript.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/QuickSkript.java
@@ -41,7 +41,7 @@ public class QuickSkript extends JavaPlugin {
      * @since 0.1.0
      */
     @Contract(pure = true)
-    public static QuickSkript getInstance() {
+    public static QuickSkript getInstance() { //TODO some unified parsing, compiler error + warn logging through this class?
         return instance;
     }
 

--- a/src/main/java/com/github/stefvanschie/quickskript/QuickSkript.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/QuickSkript.java
@@ -41,7 +41,7 @@ public class QuickSkript extends JavaPlugin {
      * @since 0.1.0
      */
     @Contract(pure = true)
-    public static QuickSkript getInstance() { //TODO some unified parsing, compiler error + warn logging through this class?
+    public static QuickSkript getInstance() {
         return instance;
     }
 

--- a/src/main/java/com/github/stefvanschie/quickskript/event/ComplexEventProxyFactory.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/event/ComplexEventProxyFactory.java
@@ -2,7 +2,6 @@ package com.github.stefvanschie.quickskript.event;
 
 import com.github.stefvanschie.quickskript.QuickSkript;
 import com.github.stefvanschie.quickskript.skript.SkriptEventExecutor;
-import javafx.util.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventPriority;
@@ -28,7 +27,7 @@ public class ComplexEventProxyFactory extends EventProxyFactory {
      * The storage of registered event handlers.
      */
     @NotNull
-    private static final Map<Class<? extends Event>, List<Pair<SkriptEventExecutor, Predicate<Event>>>> REGISTERED_HANDLERS = new HashMap<>();
+    private static final Map<Class<? extends Event>, List<Map.Entry<SkriptEventExecutor, Predicate<Event>>>> REGISTERED_HANDLERS = new HashMap<>();
 
     /**
      * The executor which handles the execution of all event handlers in the storage.
@@ -60,7 +59,7 @@ public class ComplexEventProxyFactory extends EventProxyFactory {
                 Bukkit.getPluginManager().registerEvent(event, EMPTY_LISTENER,
                         EventPriority.NORMAL, HANDLER_EXECUTOR, QuickSkript.getInstance());
                 return new ArrayList<>();
-            }).add(new Pair<>(toRegisterSupplier.get(), eventPattern.getFilterCreator().apply(matcher)));
+            }).add(Map.entry(toRegisterSupplier.get(), eventPattern.getFilterCreator().apply(matcher)));
             return true;
         }
 

--- a/src/main/java/com/github/stefvanschie/quickskript/event/SimpleEventProxyFactory.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/event/SimpleEventProxyFactory.java
@@ -2,7 +2,6 @@ package com.github.stefvanschie.quickskript.event;
 
 import com.github.stefvanschie.quickskript.QuickSkript;
 import com.github.stefvanschie.quickskript.skript.SkriptEventExecutor;
-import javafx.util.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventPriority;
@@ -39,14 +38,14 @@ public class SimpleEventProxyFactory extends EventProxyFactory {
      * The storage of the registered event patterns.
      */
     @NotNull
-    private final List<Pair<Class<? extends Event>, Pattern>> eventPatterns = new ArrayList<>();
+    private final List<Map.Entry<Class<? extends Event>, Pattern>> eventPatterns = new ArrayList<>();
 
     /**
      * {@inheritDoc}
      */
     @Override
     public boolean tryRegister(@NotNull String text, @NotNull Supplier<SkriptEventExecutor> toRegisterSupplier) {
-        for (Pair<Class<? extends Event>, Pattern> eventPattern : eventPatterns) {
+        for (Map.Entry<Class<? extends Event>, Pattern> eventPattern : eventPatterns) {
             if (!eventPattern.getValue().matcher(text).matches())
                 continue;
 
@@ -72,7 +71,7 @@ public class SimpleEventProxyFactory extends EventProxyFactory {
      */
     @NotNull
     public SimpleEventProxyFactory registerEvent(@NotNull Class<? extends Event> event, @NotNull String regex) {
-        eventPatterns.add(new Pair<>(event, Pattern.compile(regex)));
+        eventPatterns.add(Map.entry(event, Pattern.compile(regex)));
         return this;
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFile.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFile.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Represents a skript file. The source of the code does not necessary have to be a file,
@@ -67,7 +68,8 @@ public class SkriptFile {
         }
 
         //if a line is empty or only contains spaces, remove it, otherwise it'll screw the rest of the algorithm up
-        lines.replaceAll(line -> line.matches(" +") ? "" : line);
+        Pattern emptyLinePattern = Pattern.compile(" +");
+        lines.replaceAll(line -> emptyLinePattern.matcher(line).matches() ? "" : line);
 
         //remove trailing spaces and replace \t with four spaces
         for (int i = 0; i < lines.size(); i++)

--- a/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
@@ -52,11 +52,6 @@ public class SkriptFileSection extends SkriptFileNode {
     @NotNull
     @Contract(pure = true)
     public PsiElement<?>[] parseNodes() {
-        //TODO stuff to look out for:
-        // - there is a 'wait # <timestamp>' expression (maybe a preprocessor for stuff like this? - indent it?)
-        // - exit (optional number) expression exists
-        // - stop <?> expression exists
-
         Deque<PsiElement<?>> result = new ArrayDeque<>(nodes.size());
         SkriptLoader loader = SkriptLoader.get();
 

--- a/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Represents a section of skript lines
@@ -50,19 +50,16 @@ public class SkriptFileSection extends SkriptFileNode {
      */
     @NotNull
     @Contract(pure = true)
-    public List<PsiElement<?>> parseNodes() {
+    public Stream<PsiElement<?>> parseNodes() {
         //TODO stuff to look out for:
         // - else statements need to hook into the if statements
         // - the 'if' keyword is optional
         // - there is a 'wait # <timestamp>' expression (maybe a preprocessor for stuff like this? - indent it?)
-        // - loops are easy: <while/loop> <some stuff>:
-        // - inside if statements, the unhandled Boolean is probably handled just outside: halts execution if false
-        // - inside loop and while statements the unhandled boolean means continue
         // - exit (optional number) expression exists
+        // - stop <?> expression exists
 
         return getNodes().stream()
-                .map(node -> SkriptLoader.get().forceParseElement(node.getText(), node.getLineNumber()))
-                .collect(Collectors.toList());
+                .map(node -> SkriptLoader.get().forceParseElement(node.getText(), node.getLineNumber()));
     }
 
     /**

--- a/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
@@ -1,10 +1,13 @@
 package com.github.stefvanschie.quickskript.file;
 
+import com.github.stefvanschie.quickskript.psi.PsiElement;
+import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Represents a section of skript lines
@@ -39,11 +42,35 @@ public class SkriptFileSection extends SkriptFileNode {
     }
 
     /**
+     * Parses all of the nodes, including the ones inside nested
+     * {@link SkriptFileSection}s into a psi structure
+     *
+     * @return the nodes parsed into a psi structure
+     * @since 0.1.0
+     */
+    @NotNull
+    @Contract(pure = true)
+    public List<PsiElement<?>> parseNodes() {
+        //TODO stuff to look out for:
+        // - else statements need to hook into the if statements
+        // - the 'if' keyword is optional
+        // - there is a 'wait # <timestamp>' expression (maybe a preprocessor for stuff like this? - indent it?)
+        // - loops are easy: <while/loop> <some stuff>:
+        // - inside if statements, the unhandled Boolean is probably handled just outside: halts execution if false
+        // - inside loop and while statements the unhandled boolean means continue
+        // - exit (optional number) expression exists
+
+        return getNodes().stream()
+                .map(node -> SkriptLoader.get().forceParseElement(node.getText(), node.getLineNumber()))
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Parses a section from the given header and strings
      *
      * @param nodes the underlying nodes
      * @param lineNumberOffset the offset of the line number from the starting node. This value represents the line
-     *                         number of the first node in the list.
+     * number of the first node in the list.
      * @since 0.1.0
      */
     void parse(@NotNull List<String> nodes, int lineNumberOffset) {

--- a/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
@@ -1,13 +1,13 @@
 package com.github.stefvanschie.quickskript.file;
 
 import com.github.stefvanschie.quickskript.psi.PsiElement;
+import com.github.stefvanschie.quickskript.psi.section.PsiSection;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * Represents a section of skript lines
@@ -50,7 +50,7 @@ public class SkriptFileSection extends SkriptFileNode {
      */
     @NotNull
     @Contract(pure = true)
-    public Stream<PsiElement<?>> parseNodes() {
+    public PsiSection parseNodes() {
         //TODO stuff to look out for:
         // - else statements need to hook into the if statements
         // - the 'if' keyword is optional
@@ -58,8 +58,9 @@ public class SkriptFileSection extends SkriptFileNode {
         // - exit (optional number) expression exists
         // - stop <?> expression exists
 
-        return getNodes().stream()
-                .map(node -> SkriptLoader.get().forceParseElement(node.getText(), node.getLineNumber()));
+        return new PsiSection(getNodes().stream()
+                .map(node -> SkriptLoader.get().forceParseElement(node.getText(), node.getLineNumber()))
+                .toArray(PsiElement[]::new), getLineNumber());
     }
 
     /**

--- a/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/file/SkriptFileSection.java
@@ -9,7 +9,6 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.function.Supplier;
 
 /**
  * Represents a section of skript lines
@@ -79,16 +78,16 @@ public class SkriptFileSection extends SkriptFileNode {
                 text = node.getText().substring("else ".length());
             }
 
-            SkriptFileSection fileSection = (SkriptFileSection) node;
-            Supplier<PsiElement<?>[]> elementsSupplier = fileSection::parseNodes;
-            PsiSection section = loader.forceParseSection(text, elementsSupplier, node.getLineNumber());
+            PsiSection section = loader.forceParseSection(text,
+                    ((SkriptFileSection) node)::parseNodes, node.getLineNumber());
 
             if (elseSection) {
                 latestValidIf.setElseSection(section);
+            } else {
+                result.add(section);
             }
 
             latestValidIf = section instanceof PsiIf ? (PsiIf) section : null;
-            result.add(section);
         }
 
         return result.toArray(PsiElement[]::new);

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElement.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElement.java
@@ -26,12 +26,12 @@ public abstract class PsiElement<T> {
     protected final int lineNumber;
 
     /**
-     * Creates a new element with the given lien number
+     * Creates a new element with the given line number
      *
      * @param lineNumber the line number this element is associated with
      * @since 0.1.0
      */
-    public PsiElement(int lineNumber) {
+    protected PsiElement(int lineNumber) {
         this.lineNumber = lineNumber;
     }
 

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElement.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElement.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.psi;
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
 import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -55,7 +56,8 @@ public abstract class PsiElement<T> {
      * @return the computed value which is null if the computation returned null
      * @since 0.1.0
      */
-    public <R> R execute(@Nullable Context context, Class<R> forcedResult) {
+    @NotNull
+    public <R> R execute(@Nullable Context context, @NotNull Class<R> forcedResult) {
         T result = execute(context);
         if (forcedResult.isInstance(result))
             return forcedResult.cast(result);

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElement.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiElement.java
@@ -42,6 +42,7 @@ public abstract class PsiElement<T> {
      * @return the computed value which is null if the computation returned null
      * @since 0.1.0
      */
+    @Nullable
     public final T execute(@Nullable Context context) {
         return isPreComputed() ? preComputed : executeImpl(context);
     }
@@ -63,7 +64,8 @@ public abstract class PsiElement<T> {
             return forcedResult.cast(result);
 
         throw new ExecutionException("Result of " + getClass().getSimpleName() +
-                " should be a " + forcedResult.getSimpleName() + ", but it wasn't", lineNumber);
+                " should be " + forcedResult.getSimpleName() + ", but it was " +
+                (result == null ? "null" : result.getClass().getSimpleName()), lineNumber);
     }
 
     /**
@@ -73,6 +75,7 @@ public abstract class PsiElement<T> {
      * @return the computed value which is null if the computation returned null
      * @since 0.1.0
      */
+    @Nullable
     protected abstract T executeImpl(@Nullable Context context);
 
     /**

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiSection.java
@@ -1,18 +1,17 @@
-package com.github.stefvanschie.quickskript.psi.section;
+package com.github.stefvanschie.quickskript.psi;
 
 import com.github.stefvanschie.quickskript.context.Context;
-import com.github.stefvanschie.quickskript.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
-public class PsiSection extends PsiElement<Void> {
+public abstract class PsiSection extends PsiElement<Void> { //TODO docs to all classes, etc.
 
     @NotNull
-    private final PsiElement[] elements;
+    protected final PsiElement<?>[] elements;
 
-    public PsiSection(@NotNull PsiElement[] elements, int lineNumber) {
+    protected PsiSection(@NotNull PsiElement<?>[] elements, int lineNumber) {
         super(lineNumber);
         this.elements = elements;
 
@@ -21,7 +20,6 @@ public class PsiSection extends PsiElement<Void> {
             //TODO warning
         }
     }
-
 
     @Nullable
     @Override

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiSection.java
@@ -6,11 +6,28 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
-public abstract class PsiSection extends PsiElement<Void> { //TODO docs to all classes, etc.
+/**
+ * An abstract representation of a section in a skript file.
+ * Other sections should extend upon the functionality implemented in this class:
+ * it executes all contained elements in order until {@link Boolean#FALSE} is returned.
+ *
+ * @since 0.1.0
+ */
+public abstract class PsiSection extends PsiElement<Void> {
 
+    /**
+     * The elements this section contains.
+     */
     @NotNull
     protected final PsiElement<?>[] elements;
 
+    /**
+     * Creates a new section with the specified contained elements and line number.
+     *
+     * @param elements the elements this section should contain
+     * @param lineNumber the line number this element is associated with
+     * @since 0.1.0
+     */
     protected PsiSection(@NotNull PsiElement<?>[] elements, int lineNumber) {
         super(lineNumber);
         this.elements = elements;
@@ -21,6 +38,9 @@ public abstract class PsiSection extends PsiElement<Void> { //TODO docs to all c
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Nullable
     @Override
     protected Void executeImpl(@Nullable Context context) {

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiSectionFactory.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiSectionFactory.java
@@ -1,0 +1,11 @@
+package com.github.stefvanschie.quickskript.psi;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+public interface PsiSectionFactory<T extends PsiSection> {
+    @Nullable
+    T tryParse(@NotNull String text, @NotNull Supplier<PsiElement<?>[]> elementsSupplier, int lineNumber);
+}

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/PsiSectionFactory.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/PsiSectionFactory.java
@@ -5,7 +5,23 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Supplier;
 
+/**
+ * An abstract factory interface for parsing psi sections.
+ * Every section needs at least one factory, but may have more.
+ *
+ * @param <T> the type of psi section this will return
+ * @since 0.1.0
+ */
 public interface PsiSectionFactory<T extends PsiSection> {
+    /**
+     * Tries to parse the given text for this specified factory.
+     *
+     * @param text the text to be parsed
+     * @param elementsSupplier the action which parses the contained elements on demand
+     * @param lineNumber the line number of the element we're currently parsing
+     * @return the element created, or null if the element could not be created
+     * @since 0.1.0
+     */
     @Nullable
     T tryParse(@NotNull String text, @NotNull Supplier<PsiElement<?>[]> elementsSupplier, int lineNumber);
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/condition/PsiHasPermissionCondition.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/condition/PsiHasPermissionCondition.java
@@ -58,6 +58,7 @@ public class PsiHasPermissionCondition extends PsiElement<Boolean> {
     /**
      * {@inheritDoc}
      */
+    @NotNull
     @Override
     protected Boolean executeImpl(@Nullable Context context) {
         return positive == permissible

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiCancelEventEffect.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiCancelEventEffect.java
@@ -30,6 +30,7 @@ public class PsiCancelEventEffect extends PsiElement<Void> {
     /**
      * {@inheritDoc}
      */
+    @Nullable
     @Override
     protected Void executeImpl(@Nullable Context context) {
         if (!(context instanceof EventContext))

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiExplosionEffect.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiExplosionEffect.java
@@ -78,12 +78,9 @@ public class PsiExplosionEffect extends PsiElement<Void> {
             if (!(event instanceof EntityEvent) && !(event instanceof PlayerEvent))
                 throw new ExecutionException("Event wasn't performed by an entity or player", lineNumber);
 
-            Entity entity;
-
-            if (event instanceof EntityEvent)
-                entity = ((EntityEvent) event).getEntity();
-            else
-                entity = ((PlayerEvent) event).getPlayer();
+            Entity entity = event instanceof EntityEvent
+                    ? ((EntityEvent) event).getEntity()
+                    : ((PlayerEvent) event).getPlayer();
 
             Location location = entity.getLocation();
 

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiExplosionEffect.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiExplosionEffect.java
@@ -55,6 +55,7 @@ public class PsiExplosionEffect extends PsiElement<Void> {
     /**
      * {@inheritDoc}
      */
+    @Nullable
     @Override
     protected Void executeImpl(@Nullable Context context) {
         if (context == null)

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiMessageEffect.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/effect/PsiMessageEffect.java
@@ -50,6 +50,7 @@ public class PsiMessageEffect extends PsiElement<Void> {
     /**
      * {@inheritDoc}
      */
+    @Nullable
     @Override
     protected Void executeImpl(@Nullable Context context) {
         CommandSender receiver = null;

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/expression/PsiParseExpression.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/expression/PsiParseExpression.java
@@ -52,15 +52,20 @@ public class PsiParseExpression extends PsiElement<Object> {
     /**
      * {@inheritDoc}
      */
+    @Nullable
     @Override
     protected Object executeImpl(@Nullable Context context) {
-        PsiElement<?> parse = converter.convert(value.execute(context).toString(), lineNumber);
+        Object toParse = value.execute(context);
+        if (toParse == null)
+            return null; //TODO didn't think this through, no idea what should happen, please fix
+
+        PsiElement<?> parsed = converter.convert(toParse.toString(), lineNumber);
 
         //TODO: if this stuff can't be parsed, the parse error needs to be set
-        if (parse == null)
+        if (parsed == null)
             return null;
 
-        return parse.execute(context);
+        return parsed.execute(context);
     }
 
     /**

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/expression/PsiRandomNumberExpression.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/expression/PsiRandomNumberExpression.java
@@ -67,8 +67,8 @@ public class PsiRandomNumberExpression extends PsiElement<Number> {
     @NotNull
     @Override
     protected Number executeImpl(@Nullable Context context) {
-        Number minNumber = this.min.execute(context, Number.class);
-        Number maxNumber = this.max.execute(context, Number.class);
+        Number minNumber = min.execute(context, Number.class);
+        Number maxNumber = max.execute(context, Number.class);
 
         if (minNumber.doubleValue() > maxNumber.doubleValue()) {
             Number temp = maxNumber;

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiWorldFunction.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/function/PsiWorldFunction.java
@@ -41,6 +41,7 @@ public class PsiWorldFunction extends PsiElement<World> {
     /**
      * {@inheritDoc}
      */
+    @Nullable
     @Override
     public World executeImpl(@Nullable Context context) {
         return Bukkit.getWorld(parameter.execute(context, Text.class).construct());

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/literal/PsiPlayerLiteral.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/literal/PsiPlayerLiteral.java
@@ -33,6 +33,7 @@ public class PsiPlayerLiteral extends PsiElement<Player> {
     /**
      * {@inheritDoc}
      */
+    @NotNull
     @Override
     protected Player executeImpl(@Nullable Context context) {
         if (context == null)
@@ -57,7 +58,8 @@ public class PsiPlayerLiteral extends PsiElement<Player> {
             return ((PlayerEvent) event).getPlayer();
         }
 
-        throw new ExecutionException("Unknown context found when trying to parse a player", lineNumber);
+        throw new ExecutionException("Unknown context found when trying to parse a player: " +
+                context.getClass().getSimpleName(), lineNumber);
     }
 
     /**

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiBaseSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiBaseSection.java
@@ -1,0 +1,38 @@
+package com.github.stefvanschie.quickskript.psi.section;
+
+import com.github.stefvanschie.quickskript.QuickSkript;
+import com.github.stefvanschie.quickskript.context.Context;
+import com.github.stefvanschie.quickskript.file.SkriptFileSection;
+import com.github.stefvanschie.quickskript.psi.PsiSection;
+import com.github.stefvanschie.quickskript.skript.Skript;
+import com.github.stefvanschie.quickskript.skript.profiler.SkriptProfiler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PsiBaseSection extends PsiSection {
+
+    @NotNull
+    private final Class<? extends Context> contextClass;
+
+    @NotNull
+    private final SkriptProfiler.Identifier profilerIdentifier;
+
+    public PsiBaseSection(@NotNull Skript skript, @NotNull SkriptFileSection section,
+            @NotNull Class<? extends Context> contextClass) {
+        super(section.parseNodes(), section.getLineNumber());
+        this.contextClass = contextClass;
+        this.profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
+    }
+
+    @Nullable
+    @Override
+    protected Void executeImpl(@Nullable Context context) {
+        long startTime = System.nanoTime();
+
+        super.executeImpl(context);
+
+        QuickSkript.getInstance().getSkriptProfiler().onTimeMeasured(contextClass,
+                profilerIdentifier, System.nanoTime() - startTime);
+        return null;
+    }
+}

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiBaseSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiBaseSection.java
@@ -9,21 +9,43 @@ import com.github.stefvanschie.quickskript.skript.profiler.SkriptProfiler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * A section which acts as the entry point for Skript code.
+ *
+ * @since 0.1.0
+ */
 public class PsiBaseSection extends PsiSection {
 
+    /**
+     * The type of context of this entry point.
+     */
     @NotNull
-    private final Class<? extends Context> contextClass;
+    private final Class<? extends Context> contextType;
 
+    /**
+     * The identifier of this entry point.
+     */
     @NotNull
     private final SkriptProfiler.Identifier profilerIdentifier;
 
+    /**
+     * Creates a new Skript entry point.
+     *
+     * @param skript the Skript which contains this entry point
+     * @param section the section this entry point should be parsed from
+     * @param contextType the type of context of this entry point
+     * @since 0.1.0
+     */
     public PsiBaseSection(@NotNull Skript skript, @NotNull SkriptFileSection section,
-            @NotNull Class<? extends Context> contextClass) {
+            @NotNull Class<? extends Context> contextType) {
         super(section.parseNodes(), section.getLineNumber());
-        this.contextClass = contextClass;
-        this.profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
+        this.contextType = contextType;
+        profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Nullable
     @Override
     protected Void executeImpl(@Nullable Context context) {
@@ -31,7 +53,7 @@ public class PsiBaseSection extends PsiSection {
 
         super.executeImpl(context);
 
-        QuickSkript.getInstance().getSkriptProfiler().onTimeMeasured(contextClass,
+        QuickSkript.getInstance().getSkriptProfiler().onTimeMeasured(contextType,
                 profilerIdentifier, System.nanoTime() - startTime);
         return null;
     }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiIf.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiIf.java
@@ -43,6 +43,7 @@ public class PsiIf extends PsiElement<Void> {
     }
 
 
+    @Nullable
     @Override
     protected Void executeImpl(@Nullable Context context) {
         if (condition.execute(context, Boolean.class)) {

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiIf.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiIf.java
@@ -1,0 +1,55 @@
+package com.github.stefvanschie.quickskript.psi.section;
+
+import com.github.stefvanschie.quickskript.context.Context;
+import com.github.stefvanschie.quickskript.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PsiIf extends PsiElement<Void> {
+
+    @NotNull
+    private final PsiElement<?> condition;
+
+    @NotNull
+    private final PsiSection content;
+
+    @Nullable
+    private final PsiElement<?> elseElement;
+
+    public PsiIf(@NotNull PsiElement<?> condition, @NotNull PsiSection content,
+            @NotNull PsiIf elseIf, int lineNumber) {
+        this(condition, content, lineNumber, elseIf);
+    }
+
+    public PsiIf(@NotNull PsiElement<?> condition, @NotNull PsiSection content,
+            @NotNull PsiSection elseSection, int lineNumber) {
+        this(condition, content, lineNumber, elseSection);
+    }
+
+    public PsiIf(@NotNull PsiElement<?> condition, @NotNull PsiSection content, int lineNumber) {
+        this(condition, content, lineNumber, null);
+    }
+
+    private PsiIf(@NotNull PsiElement<?> condition, @NotNull PsiSection content,
+            int lineNumber, @Nullable PsiElement<?> elseElement) {
+        super(lineNumber);
+        this.condition = condition;
+        this.content = content;
+        this.elseElement = elseElement;
+
+        if (condition.isPreComputed()) {
+            //TODO warning
+        }
+    }
+
+
+    @Override
+    protected Void executeImpl(@Nullable Context context) {
+        if (condition.execute(context, Boolean.class)) {
+            content.executeImpl(context);
+        } else if (elseElement != null) {
+            elseElement.execute(context);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiIf.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiIf.java
@@ -2,55 +2,60 @@ package com.github.stefvanschie.quickskript.psi.section;
 
 import com.github.stefvanschie.quickskript.context.Context;
 import com.github.stefvanschie.quickskript.psi.PsiElement;
+import com.github.stefvanschie.quickskript.psi.PsiSection;
+import com.github.stefvanschie.quickskript.psi.PsiSectionFactory;
+import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class PsiIf extends PsiElement<Void> {
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PsiIf extends PsiSection {
 
     @NotNull
     private final PsiElement<?> condition;
 
-    @NotNull
-    private final PsiSection content;
-
     @Nullable
-    private final PsiElement<?> elseElement;
+    private PsiSection elseSection;
 
-    public PsiIf(@NotNull PsiElement<?> condition, @NotNull PsiSection content,
-            @NotNull PsiIf elseIf, int lineNumber) {
-        this(condition, content, lineNumber, elseIf);
-    }
-
-    public PsiIf(@NotNull PsiElement<?> condition, @NotNull PsiSection content,
-            @NotNull PsiSection elseSection, int lineNumber) {
-        this(condition, content, lineNumber, elseSection);
-    }
-
-    public PsiIf(@NotNull PsiElement<?> condition, @NotNull PsiSection content, int lineNumber) {
-        this(condition, content, lineNumber, null);
-    }
-
-    private PsiIf(@NotNull PsiElement<?> condition, @NotNull PsiSection content,
-            int lineNumber, @Nullable PsiElement<?> elseElement) {
-        super(lineNumber);
+    public PsiIf(@NotNull PsiElement<?>[] elements, @NotNull PsiElement<?> condition, int lineNumber) {
+        super(elements, lineNumber);
         this.condition = condition;
-        this.content = content;
-        this.elseElement = elseElement;
 
         if (condition.isPreComputed()) {
             //TODO warning
         }
     }
 
+    public void setElseSection(@NotNull PsiSection elseSection) {
+        this.elseSection = elseSection;
+    }
 
     @Nullable
     @Override
     protected Void executeImpl(@Nullable Context context) {
         if (condition.execute(context, Boolean.class)) {
-            content.executeImpl(context);
-        } else if (elseElement != null) {
-            elseElement.execute(context);
+            super.executeImpl(context);
+        } else if (elseSection != null) {
+            elseSection.execute(context);
         }
         return null;
+    }
+
+    public static class Factory implements PsiSectionFactory<PsiIf> {
+
+        private final Pattern pattern = Pattern.compile("if ([\\s\\S]+)");
+
+        @Nullable
+        @Override
+        public PsiIf tryParse(@NotNull String text, @NotNull Supplier<PsiElement<?>[]> elementsSupplier, int lineNumber) {
+            Matcher matcher = pattern.matcher(text);
+            return matcher.matches()
+                    ? new PsiIf(elementsSupplier.get(), SkriptLoader.get()
+                    .forceParseElement(matcher.group(1), lineNumber), lineNumber)
+                    : null;
+        }
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiIf.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiIf.java
@@ -12,14 +12,34 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * A section which only executes the contained elements if its condition is met.
+ * A section which gets executed when the condition is not met can be attached.
+ *
+ * @since 0.1.0
+ */
 public class PsiIf extends PsiSection {
 
+    /**
+     * The condition of the execution.
+     */
     @NotNull
     private final PsiElement<?> condition;
 
+    /**
+     * The section which should get executed if the condition is not met, if any.
+     */
     @Nullable
     private PsiSection elseSection;
 
+    /**
+     * Creates a new psi if section.
+     *
+     * @param elements the elements this section should contain
+     * @param condition the condition of the execution
+     * @param lineNumber the line number this element is associated with
+     * @since 0.1.0
+     */
     public PsiIf(@NotNull PsiElement<?>[] elements, @NotNull PsiElement<?> condition, int lineNumber) {
         super(elements, lineNumber);
         this.condition = condition;
@@ -29,10 +49,23 @@ public class PsiIf extends PsiSection {
         }
     }
 
+    /**
+     * Sets the section which should get executed if the condition is not met.
+     * Can only be called once on a single instance.
+     *
+     * @param elseSection the section to execute when the condition is not met
+     * @since 0.1.0
+     */
     public void setElseSection(@NotNull PsiSection elseSection) {
+        if (this.elseSection != null)
+            throw new IllegalStateException("An else section has already been set for this if section.");
+
         this.elseSection = elseSection;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Nullable
     @Override
     protected Void executeImpl(@Nullable Context context) {
@@ -44,10 +77,21 @@ public class PsiIf extends PsiSection {
         return null;
     }
 
+    /**
+     * A factory for creating if sections.
+     *
+     * @since 0.1.0
+     */
     public static class Factory implements PsiSectionFactory<PsiIf> {
 
+        /**
+         * The pattern to parse if sections with.
+         */
         private final Pattern pattern = Pattern.compile("if ([\\s\\S]+)");
 
+        /**
+         * {@inheritDoc}
+         */
         @Nullable
         @Override
         public PsiIf tryParse(@NotNull String text, @NotNull Supplier<PsiElement<?>[]> elementsSupplier, int lineNumber) {

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiSection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiSection.java
@@ -1,0 +1,35 @@
+package com.github.stefvanschie.quickskript.psi.section;
+
+import com.github.stefvanschie.quickskript.context.Context;
+import com.github.stefvanschie.quickskript.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+public class PsiSection extends PsiElement<Void> {
+
+    @NotNull
+    private final PsiElement[] elements;
+
+    public PsiSection(@NotNull PsiElement[] elements, int lineNumber) {
+        super(lineNumber);
+        this.elements = elements;
+
+        if (Arrays.stream(elements).anyMatch(element -> element.isPreComputed()
+                && element.execute(null) instanceof Boolean)) {
+            //TODO warning
+        }
+    }
+
+
+    @Nullable
+    @Override
+    protected Void executeImpl(@Nullable Context context) {
+        for (PsiElement<?> element : elements) {
+            if (element.execute(context) == Boolean.FALSE)
+                break;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiWhile.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiWhile.java
@@ -12,11 +12,27 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * A section which continuously executes its contained elements while the condition is met.
+ *
+ * @since 0.1.0
+ */
 public class PsiWhile extends PsiSection {
 
+    /**
+     * The condition of the continuing execution.
+     */
     @NotNull
     private final PsiElement<?> condition;
 
+    /**
+     * Creates a new psi while section.
+     *
+     * @param elements the elements this section should contain
+     * @param condition the condition of the continuing execution
+     * @param lineNumber the line number this element is associated with
+     * @since 0.1.0
+     */
     private PsiWhile(@NotNull PsiElement<?>[] elements, @NotNull PsiElement<?> condition, int lineNumber) {
         super(elements, lineNumber);
         this.condition = condition;
@@ -26,6 +42,9 @@ public class PsiWhile extends PsiSection {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Nullable
     @Override
     protected Void executeImpl(@Nullable Context context) {
@@ -35,10 +54,21 @@ public class PsiWhile extends PsiSection {
         return null;
     }
 
+    /**
+     * A factory for creating while sections.
+     *
+     * @since 0.1.0
+     */
     public static class Factory implements PsiSectionFactory<PsiWhile> {
 
+        /**
+         * The pattern to parse while sections with.
+         */
         private final Pattern pattern = Pattern.compile("while ([\\s\\S]+)");
 
+        /**
+         * {@inheritDoc}
+         */
         @Nullable
         @Override
         public PsiWhile tryParse(@NotNull String text, @NotNull Supplier<PsiElement<?>[]> elementsSupplier, int lineNumber) {

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiWhile.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/section/PsiWhile.java
@@ -1,0 +1,34 @@
+package com.github.stefvanschie.quickskript.psi.section;
+
+import com.github.stefvanschie.quickskript.context.Context;
+import com.github.stefvanschie.quickskript.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PsiWhile extends PsiElement<Void> {
+
+    @NotNull
+    private final PsiElement<?> condition;
+
+    @NotNull
+    private final PsiSection content;
+
+    public PsiWhile(@NotNull PsiElement<?> condition, @NotNull PsiSection content, int lineNumber) {
+        super(lineNumber);
+        this.condition = condition;
+        this.content = content;
+
+        if (condition.isPreComputed()) {
+            //TODO warning
+        }
+    }
+
+    @Nullable
+    @Override
+    protected Void executeImpl(@Nullable Context context) {
+        while (condition.execute(context, Boolean.class)) {
+            content.execute(context);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/github/stefvanschie/quickskript/psi/util/PsiCollection.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/psi/util/PsiCollection.java
@@ -72,9 +72,10 @@ public class PsiCollection<T> extends PsiElement<Collection<PsiElement<T>>> {
     /**
      * {@inheritDoc}
      */
-    @Override
+    @NotNull
     @Contract(pure = true)
-    protected final Collection<PsiElement<T>> executeImpl(@Nullable Context context) {
+    @Override
+    protected Collection<PsiElement<T>> executeImpl(@Nullable Context context) {
         return elements;
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/Skript.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/Skript.java
@@ -181,7 +181,6 @@ public class Skript {
                 }
 
                 value = line.getText().substring(key.length()).trim();
-
             }
         }
 

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 /**
  * Represents an arbitrary skript command handler.
@@ -61,10 +60,7 @@ public class SkriptCommandExecutor implements CommandExecutor {
         this.skript = skript;
         profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
         this.executionTarget = executionTarget;
-
-        elements = section.getNodes().stream()
-                .map(node -> SkriptLoader.get().forceParseElement(node.getText(), node.getLineNumber()))
-                .collect(Collectors.toList());
+        elements = section.parseNodes();
     }
 
     /**
@@ -80,12 +76,7 @@ public class SkriptCommandExecutor implements CommandExecutor {
 
         try {
             for (PsiElement<?> element : elements) {
-                Object result = element.execute(context);
-
-                if (!(result instanceof Boolean))
-                    continue;
-
-                if (!(Boolean) result)
+                if (element.execute(context) == Boolean.FALSE)
                     break;
             }
         } catch (ExecutionException e) {

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptCommandExecutor.java
@@ -3,7 +3,6 @@ package com.github.stefvanschie.quickskript.skript;
 import com.github.stefvanschie.quickskript.QuickSkript;
 import com.github.stefvanschie.quickskript.context.CommandContext;
 import com.github.stefvanschie.quickskript.file.SkriptFileSection;
-import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.psi.section.PsiSection;
 import com.github.stefvanschie.quickskript.skript.profiler.SkriptProfiler;
@@ -60,7 +59,7 @@ public class SkriptCommandExecutor implements CommandExecutor {
         this.skript = skript;
         profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
         this.executionTarget = executionTarget;
-        elements = new PsiSection(section.parseNodes().toArray(PsiElement[]::new), section.getLineNumber());
+        elements = section.parseNodes();
     }
 
     /**

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
@@ -3,7 +3,6 @@ package com.github.stefvanschie.quickskript.skript;
 import com.github.stefvanschie.quickskript.QuickSkript;
 import com.github.stefvanschie.quickskript.context.EventContext;
 import com.github.stefvanschie.quickskript.file.SkriptFileSection;
-import com.github.stefvanschie.quickskript.psi.PsiElement;
 import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.psi.section.PsiSection;
 import com.github.stefvanschie.quickskript.skript.profiler.SkriptProfiler;
@@ -47,7 +46,7 @@ public class SkriptEventExecutor {
     SkriptEventExecutor(@NotNull Skript skript, @NotNull SkriptFileSection section) {
         this.skript = skript;
         profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
-        elements = new PsiSection(section.parseNodes().toArray(PsiElement[]::new), section.getLineNumber());
+        elements = section.parseNodes();
     }
 
     /**

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
@@ -4,8 +4,7 @@ import com.github.stefvanschie.quickskript.QuickSkript;
 import com.github.stefvanschie.quickskript.context.EventContext;
 import com.github.stefvanschie.quickskript.file.SkriptFileSection;
 import com.github.stefvanschie.quickskript.psi.exception.ExecutionException;
-import com.github.stefvanschie.quickskript.psi.section.PsiSection;
-import com.github.stefvanschie.quickskript.skript.profiler.SkriptProfiler;
+import com.github.stefvanschie.quickskript.psi.section.PsiBaseSection;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,16 +24,10 @@ public class SkriptEventExecutor {
     private final Skript skript;
 
     /**
-     * The identifier of this instance to use with the {@link SkriptProfiler}
-     */
-    @NotNull
-    private final SkriptProfiler.Identifier profilerIdentifier;
-
-    /**
      * The elements that should get executed
      */
     @NotNull
-    private final PsiSection elements;
+    private final PsiBaseSection elements;
 
     /**
      * Constructs a new skript event.
@@ -45,8 +38,7 @@ public class SkriptEventExecutor {
      */
     SkriptEventExecutor(@NotNull Skript skript, @NotNull SkriptFileSection section) {
         this.skript = skript;
-        profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
-        elements = section.parseNodes();
+        elements = new PsiBaseSection(skript, section, EventContext.class);
     }
 
     /**
@@ -56,17 +48,11 @@ public class SkriptEventExecutor {
      * @since 0.1.0
      */
     public void execute(@NotNull Event event) {
-        long startTime = System.nanoTime();
-
         try {
             elements.execute(new EventContext(event));
         } catch (ExecutionException e) {
             QuickSkript.getInstance().getLogger().log(Level.SEVERE, "Error while executing:" +
                     e.getExtraInfo(skript.getName()), e);
-            return;
         }
-
-        QuickSkript.getInstance().getSkriptProfiler().onTimeMeasured(EventContext.class,
-                profilerIdentifier, System.nanoTime() - startTime);
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptEventExecutor.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 /**
  * Represents an arbitrary skript event handler.
@@ -48,10 +47,7 @@ public class SkriptEventExecutor {
     SkriptEventExecutor(@NotNull Skript skript, @NotNull SkriptFileSection section) {
         this.skript = skript;
         profilerIdentifier = new SkriptProfiler.Identifier(skript, section.getLineNumber());
-
-        elements = section.getNodes().stream()
-                .map(node -> SkriptLoader.get().forceParseElement(node.getText(), node.getLineNumber()))
-                .collect(Collectors.toList());
+        elements = section.parseNodes();
     }
 
     /**
@@ -66,12 +62,7 @@ public class SkriptEventExecutor {
 
         try {
             for (PsiElement<?> element : elements) {
-                Object result = element.execute(context);
-
-                if (!(result instanceof Boolean))
-                    continue;
-
-                if (!(Boolean) result)
+                if (element.execute(context) == Boolean.FALSE)
                     break;
             }
         } catch (ExecutionException e) {

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptLoader.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptLoader.java
@@ -4,9 +4,7 @@ import com.github.stefvanschie.quickskript.QuickSkript;
 import com.github.stefvanschie.quickskript.event.ComplexEventProxyFactory;
 import com.github.stefvanschie.quickskript.event.EventProxyFactory;
 import com.github.stefvanschie.quickskript.event.SimpleEventProxyFactory;
-import com.github.stefvanschie.quickskript.psi.PsiConverter;
-import com.github.stefvanschie.quickskript.psi.PsiElement;
-import com.github.stefvanschie.quickskript.psi.PsiElementFactory;
+import com.github.stefvanschie.quickskript.psi.*;
 import com.github.stefvanschie.quickskript.psi.condition.PsiHasPermissionCondition;
 import com.github.stefvanschie.quickskript.psi.effect.PsiCancelEventEffect;
 import com.github.stefvanschie.quickskript.psi.effect.PsiExplosionEffect;
@@ -19,6 +17,8 @@ import com.github.stefvanschie.quickskript.psi.function.*;
 import com.github.stefvanschie.quickskript.psi.literal.PsiNumberLiteral;
 import com.github.stefvanschie.quickskript.psi.literal.PsiPlayerLiteral;
 import com.github.stefvanschie.quickskript.psi.literal.PsiStringLiteral;
+import com.github.stefvanschie.quickskript.psi.section.PsiIf;
+import com.github.stefvanschie.quickskript.psi.section.PsiWhile;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandMap;
@@ -53,13 +53,13 @@ import java.util.function.Supplier;
 public class SkriptLoader implements AutoCloseable {
 
     /**
-     * The current loader instance or null if there are none present.
+     * The current loader instance or null if there is none present.
      */
     @Nullable
     private static SkriptLoader instance;
 
     /**
-     * Gets the current loader instance. Returns null if there are none present.
+     * Gets the current loader instance. Returns null if there is none present.
      *
      * @return the current instance
      * @since 0.1.0
@@ -75,6 +75,12 @@ public class SkriptLoader implements AutoCloseable {
      */
     @NotNull
     private final List<PsiElementFactory<?>> elements = new ArrayList<>();
+
+    /**
+     * A list of all psi section factories.
+     */
+    @NotNull
+    private final List<PsiSectionFactory<?>> sections = new ArrayList<>();
 
     /**
      * A map indexing converters by their name.
@@ -146,7 +152,7 @@ public class SkriptLoader implements AutoCloseable {
      * @since 0.1.0
      */
     @Nullable
-    @Contract("null, _ -> fail")
+    @Contract(pure = true)
     public PsiElement<?> tryParseElement(@NotNull String input, int lineNumber) {
         input = input.trim();
 
@@ -170,12 +176,41 @@ public class SkriptLoader implements AutoCloseable {
      * @since 0.1.0
      */
     @NotNull
+    @Contract(pure = true)
     public PsiElement<?> forceParseElement(@NotNull String input, int lineNumber) {
         PsiElement<?> result = tryParseElement(input, lineNumber);
         if (result != null)
             return result;
 
         throw new ParseException("Unable to find an expression named: " + input, lineNumber);
+    }
+
+
+    /**
+     * Parses a file section into a psi section.
+     * Throws a {@link ParseException} if the parsing wasn't successful.
+     *
+     * @param input the text to be parsed
+     * @param elementsSupplier the action which parses the elements on demand
+     * @param lineNumber the line number of the section that will be parsed
+     * @return the parsed psi section, or null if none were found
+     * @since 0.1.0
+     */
+    @NotNull
+    @Contract(pure = true)
+    public PsiSection forceParseSection(@NotNull String input,
+            @NotNull Supplier<PsiElement<?>[]> elementsSupplier, int lineNumber) {
+        for (PsiSectionFactory<?> factory : sections) {
+            PsiSection result = factory.tryParse(input, elementsSupplier, lineNumber);
+
+            if (result != null)
+                return result;
+        }
+
+        //fall back to an 'if' statement which doesn't start with 'if'
+        PsiElement<?> condition = forceParseElement(input, lineNumber);
+        //try to parse the condition before all elements inside the section
+        return new PsiIf(elementsSupplier.get(), condition, lineNumber);
     }
 
 
@@ -222,7 +257,7 @@ public class SkriptLoader implements AutoCloseable {
      * @since 0.1.0
      */
     public boolean tryRegisterEventExecutor(@NotNull String input,
-                                            @NotNull Supplier<SkriptEventExecutor> toRegisterSupplier) {
+            @NotNull Supplier<SkriptEventExecutor> toRegisterSupplier) {
         input = input.trim();
 
         for (EventProxyFactory factory : events) {
@@ -242,6 +277,16 @@ public class SkriptLoader implements AutoCloseable {
      */
     public void registerElement(@NotNull PsiElementFactory<?> factory) {
         elements.add(factory);
+    }
+
+    /**
+     * Registers the specified factory.
+     *
+     * @param factory the section factory to register
+     * @since 0.1.0
+     */
+    public void registerSection(@NotNull PsiSectionFactory<?> factory) {
+        sections.add(factory);
     }
 
     /**
@@ -274,7 +319,7 @@ public class SkriptLoader implements AutoCloseable {
      * @param initializer the initializer of the new command instance
      * @since 0.1.0
      */
-    public void registerCommand(String name, Consumer<PluginCommand> initializer) {
+    public void registerCommand(@NotNull String name, @NotNull Consumer<PluginCommand> initializer) {
         PluginCommand command = commandConstructor.apply(name);
         initializer.accept(command);
         commandMap.register("quickskript", command);
@@ -341,6 +386,11 @@ public class SkriptLoader implements AutoCloseable {
         registerElement(new PsiStringLiteral.Factory());
     }
 
+    private void registerDefaultSections() {
+        registerSection(new PsiIf.Factory());
+        registerSection(new PsiWhile.Factory());
+    }
+
     private void registerDefaultConverters() {
         registerConverter("number", new PsiNumberLiteral.Converter());
         registerConverter("text", new PsiStringLiteral.Converter());
@@ -349,42 +399,42 @@ public class SkriptLoader implements AutoCloseable {
     @SuppressWarnings("HardcodedFileSeparator")
     private void registerDefaultEvents() {
         registerEvent(new SimpleEventProxyFactory()
-            .registerEvent(EntityExplodeEvent.class, "on explo(?:(?:d(?:e|ing))|(?:sion))")
-            .registerEvent(PlayerCommandPreprocessEvent.class, "on command")
+                .registerEvent(EntityExplodeEvent.class, "on explo(?:(?:d(?:e|ing))|(?:sion))")
+                .registerEvent(PlayerCommandPreprocessEvent.class, "on command")
         );
 
         registerEvent(new ComplexEventProxyFactory()
-            .registerEvent(PlayerCommandPreprocessEvent.class, "on command \"([\\s\\S]+)\"", matcher -> {
-                String command = matcher.group(1); //TODO the regex of this group is probably incorrect
-                String finalCommand = command.startsWith("/") ? command.substring(1) : command;
+                .registerEvent(PlayerCommandPreprocessEvent.class, "on command \"([\\s\\S]+)\"", matcher -> {
+                    String command = matcher.group(1); //TODO the regex of this group is probably incorrect
+                    String finalCommand = command.startsWith("/") ? command.substring(1) : command;
 
-                return event -> {
-                    String message = ((PlayerCommandPreprocessEvent) event).getMessage();
-                    return message.startsWith(finalCommand, message.startsWith("/") ? 1 : 0);
-                };
-            })
-            .registerEvent(PlayerInteractEvent.class,
-                "on (?:(right|left)(?: |-)?)?(?:mouse(?: |-)?)?click(?:ing)?", matcher -> {
-                    //TODO: This expression needs to be completed in the future, since it's missing optional additional parts
+                    return event -> {
+                        String message = ((PlayerCommandPreprocessEvent) event).getMessage();
+                        return message.startsWith(finalCommand, message.startsWith("/") ? 1 : 0);
+                    };
+                })
+                .registerEvent(PlayerInteractEvent.class,
+                        "on (?:(right|left)(?: |-)?)?(?:mouse(?: |-)?)?click(?:ing)?", matcher -> {
+                            //TODO: This expression needs to be completed in the future, since it's missing optional additional parts
 
-                    String clickType = matcher.group(1);
+                            String clickType = matcher.group(1);
 
-                    if (clickType == null)
-                        return event -> true;
-                    else if (clickType.equals("left"))
-                        return event -> {
-                            Action action = ((PlayerInteractEvent) event).getAction();
-                            return action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK;
-                        };
-                    else if (clickType.equals("right"))
-                        return event -> {
-                            Action action = ((PlayerInteractEvent) event).getAction();
-                            return action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK;
-                        };
+                            if (clickType == null)
+                                return event -> true;
+                            else if (clickType.equals("left"))
+                                return event -> {
+                                    Action action = ((PlayerInteractEvent) event).getAction();
+                                    return action == Action.LEFT_CLICK_AIR || action == Action.LEFT_CLICK_BLOCK;
+                                };
+                            else if (clickType.equals("right"))
+                                return event -> {
+                                    Action action = ((PlayerInteractEvent) event).getAction();
+                                    return action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK;
+                                };
 
-                    throw new AssertionError("Unknown click type detected for event registration");
-                }
-            )
+                            throw new AssertionError("Unknown click type detected for event registration");
+                        }
+                )
         );
     }
 }

--- a/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptLoader.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/skript/SkriptLoader.java
@@ -115,6 +115,7 @@ public class SkriptLoader implements AutoCloseable {
         Validate.isTrue(instance == null, "A SkriptLoader is already present, can't create another one.");
 
         registerDefaultElements();
+        registerDefaultSections();
         registerDefaultConverters();
         registerDefaultEvents();
 
@@ -191,7 +192,7 @@ public class SkriptLoader implements AutoCloseable {
      * Throws a {@link ParseException} if the parsing wasn't successful.
      *
      * @param input the text to be parsed
-     * @param elementsSupplier the action which parses the elements on demand
+     * @param elementsSupplier the action which parses the contained elements on demand
      * @param lineNumber the line number of the section that will be parsed
      * @return the parsed psi section, or null if none were found
      * @since 0.1.0

--- a/src/main/java/com/github/stefvanschie/quickskript/util/Text.java
+++ b/src/main/java/com/github/stefvanschie/quickskript/util/Text.java
@@ -26,7 +26,7 @@ public final class Text {
      * @since 0.1.0
      */
     private Text(TextPart part) {
-        this.parts.add(part);
+        parts.add(part);
     }
 
     /**

--- a/src/test/java/com/github/stefvanschie/quickskript/TestClassBase.java
+++ b/src/test/java/com/github/stefvanschie/quickskript/TestClassBase.java
@@ -1,15 +1,22 @@
 package com.github.stefvanschie.quickskript;
 
+import com.github.stefvanschie.quickskript.file.SkriptFile;
+import com.github.stefvanschie.quickskript.skript.Skript;
 import com.github.stefvanschie.quickskript.skript.SkriptLoader;
 import org.apache.commons.lang.reflect.FieldUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.plugin.SimplePluginManager;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.*;
 import java.util.logging.Logger;
 
 import static org.mockito.Mockito.*;
@@ -19,6 +26,29 @@ import static org.mockito.Mockito.*;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestClassBase {
+
+    @NotNull
+    protected static Collection<File> getSampleSkriptFiles() {
+        URL resource = TestClassBase.class.getClassLoader().getResource("sample-skript-files");
+        File directory = new File(Objects.requireNonNull(resource).getPath());
+        return Arrays.asList(Objects.requireNonNull(directory.listFiles()));
+    }
+
+    @NotNull
+    protected static Collection<Skript> getSampleSkripts() {
+        Collection<File> files = getSampleSkriptFiles();
+        Queue<Skript> result = new ArrayDeque<>(files.size());
+
+        try {
+            for (File file : files) {
+                result.add(new Skript(SkriptFile.getName(file), SkriptFile.load(file)));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return result;
+    }
 
     @BeforeAll
     void initialize() throws ReflectiveOperationException {

--- a/src/test/java/com/github/stefvanschie/quickskript/execution/PsiNumberExecutabilityTest.java
+++ b/src/test/java/com/github/stefvanschie/quickskript/execution/PsiNumberExecutabilityTest.java
@@ -128,7 +128,7 @@ class PsiNumberExecutabilityTest extends TestClassBase {
         System.out.println("Average PsiNumberExecutabilityTest instance count: " + ((float)instanceCount / runCount));
     }
 
-    private void test(Supplier<PsiElement<Number>> supplier, boolean precomputed) throws ReflectiveOperationException {
+    private void test(@NotNull Supplier<PsiElement<Number>> supplier, boolean precomputed) throws ReflectiveOperationException {
         try {
             RunContext context = new RunContext(supplier);
             PsiElement<Number> result = next(context);
@@ -184,7 +184,7 @@ class PsiNumberExecutabilityTest extends TestClassBase {
         private final Supplier<PsiElement<Number>> directSupplier;
         private double directChance;
 
-        RunContext(Supplier<PsiElement<Number>> directSupplier) {
+        RunContext(@NotNull Supplier<PsiElement<Number>> directSupplier) {
             this.directSupplier = directSupplier;
         }
 

--- a/src/test/java/com/github/stefvanschie/quickskript/file/SkriptFileSectionTest.java
+++ b/src/test/java/com/github/stefvanschie/quickskript/file/SkriptFileSectionTest.java
@@ -1,0 +1,90 @@
+package com.github.stefvanschie.quickskript.file;
+
+import com.github.stefvanschie.quickskript.TestClassBase;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+/**
+ * Tests whether the {@link SkriptFileSection}
+ * class correctly parses the sections.
+ */
+@SuppressWarnings("HardcodedLineSeparator")
+class SkriptFileSectionTest extends TestClassBase {
+
+    private static final String INDENTATION = "    ";
+
+    private final BiFunction<String, Integer, SkriptFileSection> sectionConstructor;
+    private final BiConsumer<SkriptFileSection, Object[]> sectionParser;
+
+    SkriptFileSectionTest() throws ReflectiveOperationException {
+        Constructor<SkriptFileSection> constructor = SkriptFileSection.class.getDeclaredConstructor(String.class, int.class);
+        constructor.setAccessible(true);
+        sectionConstructor = (text, lineNumber) -> {
+            try {
+                return constructor.newInstance(text, lineNumber);
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        Method parser = SkriptFileSection.class.getDeclaredMethod("parse", List.class, int.class);
+        parser.setAccessible(true);
+        sectionParser = (section, parameters) -> {
+            try {
+                parser.invoke(section, parameters);
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+
+    @Test
+    void test() {
+        String text = "call\n" +
+                "branch:\n" +
+                "    call\n" +
+                "    call\n" +
+                "branch:\n" +
+                "    call\n" +
+                "    branch:\n" +
+                "        call" +
+                "call";
+
+        SkriptFileSection root = sectionConstructor.apply("", 1);
+        sectionParser.accept(root, new Object[]{Arrays.asList(text.split("\n")), 1});
+
+        StringBuilder builder = new StringBuilder();
+        appendSection(builder, root, 0);
+
+        String result = builder.toString();
+        result = result.substring(0, result.length() - 1); //trailing newline
+        Assertions.assertEquals(text, result);
+    }
+
+    private void appendSection(@NotNull StringBuilder builder, @NotNull SkriptFileSection section, int indentationLevel) {
+        for (SkriptFileNode node : section.getNodes()) {
+            for (int i = 0; i < indentationLevel; i++) {
+                builder.append(INDENTATION);
+            }
+
+            builder.append(node.getText());
+
+            if (!(node instanceof SkriptFileSection)) {
+                builder.append('\n');
+                continue;
+            }
+
+            builder.append(":\n");
+            appendSection(builder, (SkriptFileSection) node, indentationLevel + 1);
+        }
+    }
+}

--- a/src/test/java/com/github/stefvanschie/quickskript/file/SkriptFileSectionTest.java
+++ b/src/test/java/com/github/stefvanschie/quickskript/file/SkriptFileSectionTest.java
@@ -19,6 +19,9 @@ import java.util.function.BiFunction;
 @SuppressWarnings("HardcodedLineSeparator")
 class SkriptFileSectionTest extends TestClassBase {
 
+    //TODO similar test, but one which relies on SkriptFileSection#parseNodes() maybe?
+    //same or separate class?
+
     private static final String INDENTATION = "    ";
 
     private final BiFunction<String, Integer, SkriptFileSection> sectionConstructor;

--- a/src/test/java/com/github/stefvanschie/quickskript/parsing/SkriptFileParseTest.java
+++ b/src/test/java/com/github/stefvanschie/quickskript/parsing/SkriptFileParseTest.java
@@ -1,15 +1,9 @@
 package com.github.stefvanschie.quickskript.parsing;
 
 import com.github.stefvanschie.quickskript.TestClassBase;
-import com.github.stefvanschie.quickskript.file.SkriptFile;
 import com.github.stefvanschie.quickskript.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.skript.Skript;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.util.Objects;
 
 /**
  * A test which asserts that all specified skript files
@@ -18,19 +12,14 @@ import java.util.Objects;
 class SkriptFileParseTest extends TestClassBase {
 
     @Test
-    void test() throws IOException {
-        URL resource = getClass().getClassLoader().getResource("skript-file-parse-test");
-        File directory = new File(Objects.requireNonNull(resource).getPath());
-
-        for (File file : Objects.requireNonNull(directory.listFiles())) {
-            String name = SkriptFile.getName(file);
-            Skript skript = new Skript(name, SkriptFile.load(file));
-
+    void test() {
+        for (Skript skript : getSampleSkripts()) {
             try {
                 skript.registerCommands();
                 skript.registerEventExecutors();
+                System.out.println("Successfully parsed: " + skript.getName());
             } catch (ParseException e) {
-                throw new AssertionError("Error while parsing:" + e.getExtraInfo(name), e);
+                throw new AssertionError("Error while parsing:" + e.getExtraInfo(skript.getName()), e);
             }
         }
     }

--- a/src/test/java/com/github/stefvanschie/quickskript/parsing/SkriptFileSectionParseTest.java
+++ b/src/test/java/com/github/stefvanschie/quickskript/parsing/SkriptFileSectionParseTest.java
@@ -1,6 +1,8 @@
-package com.github.stefvanschie.quickskript.file;
+package com.github.stefvanschie.quickskript.parsing;
 
 import com.github.stefvanschie.quickskript.TestClassBase;
+import com.github.stefvanschie.quickskript.file.SkriptFileNode;
+import com.github.stefvanschie.quickskript.file.SkriptFileSection;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -17,17 +19,14 @@ import java.util.function.BiFunction;
  * class correctly parses the sections.
  */
 @SuppressWarnings("HardcodedLineSeparator")
-class SkriptFileSectionTest extends TestClassBase {
-
-    //TODO similar test, but one which relies on SkriptFileSection#parseNodes() maybe?
-    //same or separate class?
+class SkriptFileSectionParseTest extends TestClassBase {
 
     private static final String INDENTATION = "    ";
 
     private final BiFunction<String, Integer, SkriptFileSection> sectionConstructor;
     private final BiConsumer<SkriptFileSection, Object[]> sectionParser;
 
-    SkriptFileSectionTest() throws ReflectiveOperationException {
+    SkriptFileSectionParseTest() throws ReflectiveOperationException {
         Constructor<SkriptFileSection> constructor = SkriptFileSection.class.getDeclaredConstructor(String.class, int.class);
         constructor.setAccessible(true);
         sectionConstructor = (text, lineNumber) -> {

--- a/src/test/resources/sample-skript-files/Basic-sections.sk
+++ b/src/test/resources/sample-skript-files/Basic-sections.sk
@@ -1,0 +1,3 @@
+on command:
+    message "test" to the console
+    #TODO write this sample once boolean expressions get implemented

--- a/src/test/resources/sample-skript-files/Simple-with-comments.sk
+++ b/src/test/resources/sample-skript-files/Simple-with-comments.sk
@@ -6,4 +6,4 @@ command /message: #Another comment
         message "Hi!" to the console
 
 on command:
-    message "This is Sample." to the console
+    message "This is a sample." to the console


### PR DESCRIPTION
I have updated the `pom.xml` to use Java 11 and I have implemented some basic sections. It is worth highlighting that `PsiBaseSection` is a `PsiSection` with no special implementation behind it apart from the profiling. It should be used for the entry points. Sections got their own category in `SkriptLoader`. `SkriptFileSection#parseNodes()` is a very important (newly added) method.