### PR TITLE
make SkriptProfiler not stataic

### DIFF
--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/plugin/ExecuteCommand.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/plugin/ExecuteCommand.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.bukkit.context.ExecuteContextImpl;
 import com.github.stefvanschie.quickskript.bukkit.util.CommandMapWrapper;
 import com.github.stefvanschie.quickskript.core.skript.SingleLineSkript;
 import com.github.stefvanschie.quickskript.core.skript.SkriptLoader;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -23,27 +24,36 @@ public class ExecuteCommand implements CommandExecutor {
     /**
      * The skript loader
      */
-    private SkriptLoader skriptLoader;
+    private final SkriptLoader skriptLoader;
+
+    /**
+     * The skript run environment
+     */
+    private final SkriptRunEnvironment environment;
 
     /**
      * Creates a new execute command
      *
      * @param skriptLoader the associated skript loader
+     * @param environment the associated run environment
      * @since 0.1.0
      */
-    private ExecuteCommand(@NotNull SkriptLoader skriptLoader) {
+    private ExecuteCommand(@NotNull SkriptLoader skriptLoader,
+            @NotNull SkriptRunEnvironment environment) {
         this.skriptLoader = skriptLoader;
+        this.environment = environment;
     }
 
     /**
      * Registers this {@link CommandExecutor} into Bukkit's command system.
      */
-    public static void register(@NotNull SkriptLoader skriptLoader) {
+    public static void register(@NotNull SkriptLoader skriptLoader,
+            @NotNull SkriptRunEnvironment environment) {
         var wrapper = new CommandMapWrapper();
         PluginCommand command = wrapper.create("skexec");
         command.setPermission("quickskript.exec");
         command.setDescription("Allows the execution of single line Skripts from the chat.");
-        command.setExecutor(new ExecuteCommand(skriptLoader));
+        command.setExecutor(new ExecuteCommand(skriptLoader, environment));
         wrapper.register(command);
     }
 
@@ -56,7 +66,7 @@ public class ExecuteCommand implements CommandExecutor {
         var skript = new SingleLineSkript(skriptLoader, input);
         Object result = skript.getParsedElement() == null
                 ? null
-                : skript.execute(new ExecuteContextImpl(skript, sender));
+                : skript.execute(environment, new ExecuteContextImpl(skript, sender));
         long deltaMillis = (System.nanoTime() - startTime) / 1000000;
 
         String output = ChatColor.YELLOW + "Output: " + (skript.getParsedElement() == null

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiCanFlyConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiCanFlyConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiCanFlyCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiCanFlyConditionImpl extends PsiCanFlyCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == player.execute(context, Player.class).getAllowFlight();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == player.execute(environment, context, Player.class).getAllowFlight();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiCanSeeConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiCanSeeConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiCanSeeCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -32,8 +33,8 @@ public class PsiCanSeeConditionImpl extends PsiCanSeeCondition {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == player.execute(context, Player.class).canSee(targetPlayer.execute(context, Player.class));
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == player.execute(environment, context, Player.class).canSee(targetPlayer.execute(environment, context, Player.class));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiEventCancelledConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiEventCancelledConditionImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiEventCancelledCondition;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Contract;
@@ -33,7 +34,7 @@ public class PsiEventCancelledConditionImpl extends PsiEventCancelledCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Can't check whether the event was cancelled, since there is no event",
                 lineNumber);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiHasClientWeatherConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiHasClientWeatherConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiHasClientWeatherCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiHasClientWeatherConditionImpl extends PsiHasClientWeatherConditi
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == (player.execute(context, Player.class).getPlayerWeather() != null);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == (player.execute(environment, context, Player.class).getPlayerWeather() != null);
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiHasPermissionConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiHasPermissionConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiHasPermissionCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.permissions.Permissible;
 import org.jetbrains.annotations.NotNull;
@@ -23,9 +24,9 @@ public class PsiHasPermissionConditionImpl extends PsiHasPermissionCondition {
 
     @NotNull
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return positive == permissible
-            .execute(context, Permissible.class).hasPermission(permission.execute(context, Text.class).toString());
+            .execute(environment, context, Permissible.class).hasPermission(permission.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiHasPlayedBeforeConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiHasPlayedBeforeConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiHasPlayedBeforeCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -23,8 +24,8 @@ public class PsiHasPlayedBeforeConditionImpl extends PsiHasPlayedBeforeCondition
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == player.execute(context, OfflinePlayer.class).hasPlayedBefore();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == player.execute(environment, context, OfflinePlayer.class).hasPlayedBefore();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiHasScoreboardTagConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiHasScoreboardTagConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiHasScoreboardTagCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Contract;
@@ -34,10 +35,10 @@ public class PsiHasScoreboardTagConditionImpl extends PsiHasScoreboardTagConditi
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        Entity entity = this.entity.execute(context, Entity.class);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Entity entity = this.entity.execute(environment, context, Entity.class);
 
-        return positive == entity.getScoreboardTags().contains(tag.execute(context, Text.class).toString());
+        return positive == entity.getScoreboardTags().contains(tag.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsAliveConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsAliveConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsAliveCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.LivingEntity;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiIsAliveConditionImpl extends PsiIsAliveCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == !livingEntity.execute(context, LivingEntity.class).isDead();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == !livingEntity.execute(environment, context, LivingEntity.class).isDead();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsBannedConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsBannedConditionImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsBannedCondition;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -36,8 +37,8 @@ public class PsiIsBannedConditionImpl extends PsiIsBannedCondition {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        Object object = this.object.execute(context);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = this.object.execute(environment, context);
         BanList banList = Bukkit.getBanList(ipBan ? BanList.Type.IP : BanList.Type.NAME);
 
         if (object instanceof OfflinePlayer) {

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsBlockingConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsBlockingConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsBlockingCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiIsBlockingConditionImpl extends PsiIsBlockingCondition {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == player.execute(context, Player.class).isBlocking();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == player.execute(environment, context, Player.class).isBlocking();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsBurningConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsBurningConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsBurningCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiIsBurningConditionImpl extends PsiIsBurningCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == (entity.execute(context, Entity.class).getFireTicks() > 0);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == (entity.execute(environment, context, Entity.class).getFireTicks() > 0);
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsFlyingConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsFlyingConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsFlyingCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiIsFlyingConditionImpl extends PsiIsFlyingCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == player.execute(context, Player.class).isFlying();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == player.execute(environment, context, Player.class).isFlying();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsOnGroundConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsOnGroundConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsOnGroundCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiIsOnGroundConditionImpl extends PsiIsOnGroundCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == entity.execute(context, Entity.class).isOnGround();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == entity.execute(environment, context, Entity.class).isOnGround();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsOnlineConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsOnlineConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsOnlineCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -30,8 +31,8 @@ public class PsiIsOnlineConditionImpl extends PsiIsOnlineCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == offlinePlayer.execute(context, OfflinePlayer.class).isOnline();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == offlinePlayer.execute(environment, context, OfflinePlayer.class).isOnline();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsPoisonedConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsPoisonedConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsPoisonedCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.Contract;
@@ -32,8 +33,8 @@ public class PsiIsPoisonedConditionImpl extends PsiIsPoisonedCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == livingEntity.execute(context, LivingEntity.class).hasPotionEffect(PotionEffectType.POISON);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == livingEntity.execute(environment, context, LivingEntity.class).hasPotionEffect(PotionEffectType.POISON);
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsSleepingConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsSleepingConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsSleepingCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiIsSleepingConditionImpl extends PsiIsSleepingCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == player.execute(context, Player.class).isSleeping();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == player.execute(environment, context, Player.class).isSleeping();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsSneakingConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsSneakingConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsSneakingCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiIsSneakingConditionImpl extends PsiIsSneakingCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == player.execute(context, Player.class).isSneaking();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == player.execute(environment, context, Player.class).isSneaking();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsSprintingConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsSprintingConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsSprintingCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiIsSprintingConditionImpl extends PsiIsSprintingCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == player.execute(context, Player.class).isSprinting();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == player.execute(environment, context, Player.class).isSprinting();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsSwimmingConditionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/condition/PsiIsSwimmingConditionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.condition;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.condition.PsiIsSwimmingCondition;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.LivingEntity;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,8 +32,8 @@ public class PsiIsSwimmingConditionImpl extends PsiIsSwimmingCondition {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == livingEntity.execute(context, LivingEntity.class).isSwimming();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == livingEntity.execute(environment, context, LivingEntity.class).isSwimming();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiActionBarEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiActionBarEffectImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.bukkit.util.Platform;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiActionBarEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -32,13 +33,13 @@ public class PsiActionBarEffectImpl extends PsiActionBarEffect {
     }
 
     @Nullable
-    @Contract(value = "_ -> null", pure = true)
+    @Contract(value = "_, _ -> null", pure = true)
     @SuppressWarnings("deprecation")
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         Platform platform = Platform.getPlatform();
-        Player player = this.player.execute(context, Player.class);
-        String text = this.text.execute(context, Text.class).toString();
+        Player player = this.player.execute(environment, context, Player.class);
+        String text = this.text.execute(environment, context, Text.class).toString();
 
         if (platform.isAvailable(Platform.PAPER)) {
             player.sendActionBar(text);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiBanEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiBanEffectImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiBanEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -34,12 +35,12 @@ public class PsiBanEffectImpl extends PsiBanEffect {
     }
 
     @Nullable
-    @Contract(value = "_ -> null", pure = true)
+    @Contract(value = "_, _ -> null", pure = true)
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        Object object = this.object.execute(context);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = this.object.execute(environment, context);
         BanList banList = Bukkit.getBanList(ipBan ? BanList.Type.IP : BanList.Type.NAME);
-        String reason = this.reason == null ? null : this.reason.execute(context, Text.class).toString();
+        String reason = this.reason == null ? null : this.reason.execute(environment, context, Text.class).toString();
 
         if (object instanceof Text) {
             banList.addBan(object.toString(), reason, null, null);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiCancelEventEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiCancelEventEffectImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiCancelEventEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -23,7 +24,7 @@ public class PsiCancelEventEffectImpl extends PsiCancelEventEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Code is not being run from an event and thus can't cancel anything.",
                 lineNumber);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiCloseInventoryEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiCloseInventoryEffectImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.bukkit.util.Platform;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiCloseInventoryEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.jetbrains.annotations.Contract;
@@ -30,8 +31,8 @@ public class PsiCloseInventoryEffectImpl extends PsiCloseInventoryEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        HumanEntity humanEntity = this.humanEntity.execute(context, HumanEntity.class);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        HumanEntity humanEntity = this.humanEntity.execute(environment, context, HumanEntity.class);
 
         if (Platform.getPlatform().isAvailable(Platform.PAPER)) {
             humanEntity.closeInventory(InventoryCloseEvent.Reason.PLUGIN);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiCommandEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiCommandEffectImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.bukkit.context.ContextImpl;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiCommandEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -32,13 +33,13 @@ public class PsiCommandEffectImpl extends PsiCommandEffect {
     }
 
     @Nullable
-    @Contract(value = "_ -> null", pure = true)
+    @Contract(value = "_, _ -> null", pure = true)
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         CommandSender sender = null;
 
         if (commandSender != null) {
-            sender = commandSender.execute(context, CommandSender.class);
+            sender = commandSender.execute(environment, context, CommandSender.class);
         }
 
         if (sender == null && context != null) {
@@ -49,7 +50,7 @@ public class PsiCommandEffectImpl extends PsiCommandEffect {
             sender = Bukkit.getConsoleSender();
         }
 
-        Bukkit.dispatchCommand(sender, commandName.execute(context, Text.class).toString());
+        Bukkit.dispatchCommand(sender, commandName.execute(environment, context, Text.class).toString());
 
         return null;
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiExplosionEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiExplosionEffectImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiExplosionEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
@@ -33,7 +34,7 @@ public class PsiExplosionEffectImpl extends PsiExplosionEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (context == null) {
             throw new ExecutionException("Context cannot be absent", lineNumber);
         }
@@ -52,7 +53,7 @@ public class PsiExplosionEffectImpl extends PsiExplosionEffect {
         Location location = entity.getLocation();
 
         entity.getWorld().createExplosion(location.getX(),
-            location.getY(), location.getZ(), force.execute(context, Number.class).floatValue(), !safe, !safe);
+            location.getY(), location.getZ(), force.execute(environment, context, Number.class).floatValue(), !safe, !safe);
 
         return null;
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiFeedEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiFeedEffectImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.effect;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiFeedEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,15 +29,15 @@ public class PsiFeedEffectImpl extends PsiFeedEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        Player player = this.player.execute(context, Player.class);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Player player = this.player.execute(environment, context, Player.class);
 
         if (amount == null) {
             player.setFoodLevel(20);
             return null;
         }
 
-        Number amount = this.amount.execute(context, Number.class);
+        Number amount = this.amount.execute(environment, context, Number.class);
 
         player.setFoodLevel(player.getFoodLevel() + (int) amount.doubleValue());
         return null;

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiFlyEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiFlyEffectImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.effect;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiFlyEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,8 +29,8 @@ public class PsiFlyEffectImpl extends PsiFlyEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        Player player = this.player.execute(context, Player.class);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Player player = this.player.execute(environment, context, Player.class);
 
         player.setAllowFlight(enable);
         player.setFlying(enable);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiHidePlayerFromServerListEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiHidePlayerFromServerListEffectImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiHidePlayerFromServerListEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.server.ServerListPingEvent;
@@ -34,7 +35,7 @@ public class PsiHidePlayerFromServerListEffectImpl extends PsiHidePlayerFromServ
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Code needs to be run from an event trigger", lineNumber);
         }
@@ -45,7 +46,7 @@ public class PsiHidePlayerFromServerListEffectImpl extends PsiHidePlayerFromServ
             throw new ExecutionException("Code needs to be run from a server list ping trigger", lineNumber);
         }
 
-        Player player = this.player.execute(context, Player.class);
+        Player player = this.player.execute(environment, context, Player.class);
         Iterator<Player> iterator = ((ServerListPingEvent) event).iterator();
 
         while (iterator.hasNext()) {

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiKickEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiKickEffectImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.effect;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiKickEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -29,10 +30,10 @@ public class PsiKickEffectImpl extends PsiKickEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        String reason = this.reason == null ? null : this.reason.execute(context, Text.class).toString();
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        String reason = this.reason == null ? null : this.reason.execute(environment, context, Text.class).toString();
 
-        player.execute(context, Player.class).kickPlayer(reason);
+        player.execute(environment, context, Player.class).kickPlayer(reason);
 
         return null;
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiKillEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiKillEffectImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.effect;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiKillEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Damageable;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -28,8 +29,8 @@ public class PsiKillEffectImpl extends PsiKillEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        entity.execute(context, Damageable.class).setHealth(0);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        entity.execute(environment, context, Damageable.class).setHealth(0);
 
         return null;
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiLoadServerIconEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiLoadServerIconEffectImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiLoadServerIconEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.TemporaryCache;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.Bukkit;
@@ -32,8 +33,8 @@ public class PsiLoadServerIconEffectImpl extends PsiLoadServerIconEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        String path = this.path.execute(context, Text.class).toString();
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        String path = this.path.execute(environment, context, Text.class).toString();
 
         try {
             TemporaryCache.set("last-server-icon", Bukkit.loadServerIcon(new File(path)));

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiLogEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiLogEffectImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiLogEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -38,16 +39,16 @@ public class PsiLogEffectImpl extends PsiLogEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         var instance = QuickSkript.getInstance();
-        String text = this.text.execute(context, Text.class).toString();
+        String text = this.text.execute(environment, context, Text.class).toString();
 
         if (fileName == null) {
             String prefix = context == null ? "" : '[' + context.getSkript().getName() + "] ";
 
             instance.getLogger().info(prefix + text);
         } else {
-            String fileName = this.fileName.execute(context, Text.class).toString();
+            String fileName = this.fileName.execute(environment, context, Text.class).toString();
 
             if (!fileName.endsWith(".log")) {
                 fileName += ".log";

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiMessageEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiMessageEffectImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiMessageEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.util.PsiCollection;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -31,13 +32,13 @@ public class PsiMessageEffectImpl extends PsiMessageEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         CommandSender receiver = null;
 
         if (this.receiver == null && context != null) {
             receiver = ((ContextImpl) context).getCommandSender();
         } else if (this.receiver != null) {
-            receiver = this.receiver.execute(context, CommandSender.class);
+            receiver = this.receiver.execute(environment, context, CommandSender.class);
         }
 
         if (receiver == null) {
@@ -46,7 +47,7 @@ public class PsiMessageEffectImpl extends PsiMessageEffect {
             );
         }
 
-        Object object = Objects.requireNonNull(message.execute(context));
+        Object object = Objects.requireNonNull(message.execute(environment, context));
         CommandSender finalReceiver = receiver;
         PsiCollection.forEach(object, e -> finalReceiver.sendMessage(String.valueOf(e)), null);
         return null;

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiOpEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiOpEffectImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.effect;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiOpEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -30,8 +31,8 @@ public class PsiOpEffectImpl extends PsiOpEffect {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        offlinePlayer.execute(context, OfflinePlayer.class).setOp(op);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        offlinePlayer.execute(environment, context, OfflinePlayer.class).setOp(op);
 
         return null;
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiPlayerInfoEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiPlayerInfoEffectImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiPlayerInfoEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +32,7 @@ public class PsiPlayerInfoEffectImpl extends PsiPlayerInfoEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Code needs to be ran from within an event", lineNumber);
         }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiPlayerVisibilityEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiPlayerVisibilityEffectImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.bukkit.plugin.QuickSkript;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiPlayerVisibilityEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
@@ -36,12 +37,12 @@ public class PsiPlayerVisibilityEffectImpl extends PsiPlayerVisibilityEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         Collection<? extends Player> targets = target == null
                 ? Bukkit.getOnlinePlayers()
-                : Collections.singleton(target.execute(context, Player.class));
+                : Collections.singleton(target.execute(environment, context, Player.class));
 
-        Player player = this.player.execute(context, Player.class);
+        Player player = this.player.execute(environment, context, Player.class);
 
         targets.forEach(target -> {
             if (show) {

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiResetTitleEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiResetTitleEffectImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiResetTitleEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
@@ -31,7 +32,7 @@ public class PsiResetTitleEffectImpl extends PsiResetTitleEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         Player player;
 
         if (this.player == null) {
@@ -47,7 +48,7 @@ public class PsiResetTitleEffectImpl extends PsiResetTitleEffect {
                 throw new ExecutionException("Unable to find a player to reset the title for", lineNumber);
             }
         } else {
-            player = this.player.execute(context, Player.class);
+            player = this.player.execute(environment, context, Player.class);
         }
 
         player.resetTitle();

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiSayEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiSayEffectImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.effect;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiSayEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
@@ -30,8 +31,8 @@ public class PsiSayEffectImpl extends PsiSayEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        player.execute(context, Player.class).chat(text.execute(context, Text.class).toString());
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        player.execute(environment, context, Player.class).chat(text.execute(environment, context, Text.class).toString());
 
         return null;
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiShearEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiShearEffectImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.effect;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiShearEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Sheep;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,8 +30,8 @@ public class PsiShearEffectImpl extends PsiShearEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        sheep.execute(context, Sheep.class).setSheared(shear);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        sheep.execute(environment, context, Sheep.class).setSheared(shear);
 
         return null;
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiToggleFlightEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiToggleFlightEffectImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.effect;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiToggleFlightEffect;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -28,8 +29,8 @@ public class PsiToggleFlightEffectImpl extends PsiToggleFlightEffect {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        player.execute(context, Player.class).setAllowFlight(enabled);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        player.execute(environment, context, Player.class).setAllowFlight(enabled);
 
         return null;
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiUnbanEffectImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/effect/PsiUnbanEffectImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiUnbanEffect;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -32,10 +33,10 @@ public class PsiUnbanEffectImpl extends PsiUnbanEffect {
     }
 
     @Nullable
-    @Contract(value = "_ -> null", pure = true)
+    @Contract(value = "_, _ -> null", pure = true)
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        Object object = this.object.execute(context);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = this.object.execute(environment, context);
         BanList banList = Bukkit.getBanList(ipBan ? BanList.Type.IP : BanList.Type.NAME);
 
         if (object instanceof Text) {

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiAttackerExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiAttackerExpressionImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiAttackerExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.apache.commons.lang.Validate;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Event;
@@ -71,7 +72,7 @@ public class PsiAttackerExpressionImpl extends PsiAttackerExpression {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Object executeImpl(@Nullable Context context) {
+    protected Object executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("The attacker can only be gotten in events", lineNumber);
         }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiBukkitVersionExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiBukkitVersionExpressionImpl.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiBukkitVersionExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Contract;
@@ -28,7 +29,7 @@ public class PsiBukkitVersionExpressionImpl extends PsiBukkitVersionExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return Text.parseLiteral(Bukkit.getBukkitVersion());
     }
 

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiChatMessageExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiChatMessageExpressionImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiChatMessageExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -38,7 +39,7 @@ public class PsiChatMessageExpressionImpl extends PsiChatMessageExpression {
     @Contract(pure = true)
     @Override
     @SuppressWarnings("deprecation")
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Chat message can only be retrieved from events", lineNumber);
         }
@@ -61,13 +62,13 @@ public class PsiChatMessageExpressionImpl extends PsiChatMessageExpression {
      */
     @Override
     @SuppressWarnings("deprecation")
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Chat message can only be retrieved from events", lineNumber);
         }
 
         Event event = ((EventContextImpl) context).getEvent();
-        String message = object.execute(context, Text.class).toString();
+        String message = object.execute(environment, context, Text.class).toString();
 
         if (event instanceof AsyncPlayerChatEvent) {
             ((AsyncPlayerChatEvent) event).setMessage(message);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiCommandExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiCommandExpressionImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiCommandExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.server.ServerCommandEvent;
@@ -32,7 +33,7 @@ public class PsiCommandExpressionImpl extends PsiCommandExpression {
 
     @NotNull
     @Override
-    protected String executeImpl(@Nullable Context context) {
+    protected String executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Command expression can only be used inside events", lineNumber);
         }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiCommandSenderExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiCommandSenderExpressionImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiCommandSenderExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Contract;
@@ -48,7 +49,7 @@ public class PsiCommandSenderExpressionImpl extends PsiCommandSenderExpression {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Object executeImpl(@Nullable Context context) {
+    protected Object executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Command sender expression can only be used from inside an event", lineNumber);
         }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDamageExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDamageExpressionImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiDamageExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.vehicle.VehicleDamageEvent;
@@ -32,7 +33,7 @@ public class PsiDamageExpressionImpl extends PsiDamageExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Double executeImpl(@Nullable Context context) {
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Damage expression can only be called from events", lineNumber);
         }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDeathMessageExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDeathMessageExpressionImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiDeathMessageExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -33,7 +34,7 @@ public class PsiDeathMessageExpressionImpl extends PsiDeathMessageExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Death message expression can only be executed from an event", lineNumber);
         }
@@ -49,7 +50,7 @@ public class PsiDeathMessageExpressionImpl extends PsiDeathMessageExpression {
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Death message expression can only be executed from an event", lineNumber);
         }
@@ -61,7 +62,7 @@ public class PsiDeathMessageExpressionImpl extends PsiDeathMessageExpression {
                 lineNumber);
         }
 
-        ((PlayerDeathEvent) event).setDeathMessage(object.execute(context, Text.class).toString());
+        ((PlayerDeathEvent) event).setDeathMessage(object.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDefaultMOTDExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDefaultMOTDExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiDefaultMOTDExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Contract;
@@ -33,7 +34,7 @@ public class PsiDefaultMOTDExpressionImpl extends PsiDefaultMOTDExpression {
      */
     @NotNull
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         throw new ExecutionException(new IllegalStateException("Default MOTD is always pre-computed"), lineNumber);
     }
 

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDefaultServerIconExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDefaultServerIconExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiDefaultServerIconExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.Bukkit;
 import org.bukkit.util.CachedServerIcon;
 import org.jetbrains.annotations.Contract;
@@ -31,7 +32,7 @@ public class PsiDefaultServerIconExpressionImpl extends PsiDefaultServerIconExpr
     @NotNull
     @Contract(pure = true)
     @Override
-    protected CachedServerIcon executeImpl(@Nullable Context context) {
+    protected CachedServerIcon executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         throw new ExecutionException("This expression is always pre-computed", lineNumber);
     }
 

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDisplayedMOTDExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiDisplayedMOTDExpressionImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiDisplayedMOTDExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
@@ -34,7 +35,7 @@ public class PsiDisplayedMOTDExpressionImpl extends PsiDisplayedMOTDExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Expression can only be executed from an event", lineNumber);
         }
@@ -49,7 +50,7 @@ public class PsiDisplayedMOTDExpressionImpl extends PsiDisplayedMOTDExpression {
     }
 
     @Override
-    public void delete(@Nullable Context context) {
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Expression can only be executed from an event", lineNumber);
         }
@@ -64,7 +65,7 @@ public class PsiDisplayedMOTDExpressionImpl extends PsiDisplayedMOTDExpression {
     }
 
     @Override
-    public void reset(@Nullable Context context) {
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Expression can only be executed from an event", lineNumber);
         }
@@ -79,7 +80,7 @@ public class PsiDisplayedMOTDExpressionImpl extends PsiDisplayedMOTDExpression {
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Expression can only be executed from an event", lineNumber);
         }
@@ -90,7 +91,7 @@ public class PsiDisplayedMOTDExpressionImpl extends PsiDisplayedMOTDExpression {
             throw new ExecutionException("Expression can only be executed from a ping event", lineNumber);
         }
 
-        ((ServerListPingEvent) event).setMotd(object.execute(context, Text.class).toString());
+        ((ServerListPingEvent) event).setMotd(object.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiExhaustionExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiExhaustionExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiExhaustionExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -29,42 +30,42 @@ public class PsiExhaustionExpressionImpl extends PsiExhaustionExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Float executeImpl(@Nullable Context context) {
-        return player.execute(context, Player.class).getExhaustion();
+    protected Float executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return player.execute(environment, context, Player.class).getExhaustion();
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
 
-        player.setExhaustion(player.getExhaustion() + object.execute(context, Number.class).floatValue());
+        player.setExhaustion(player.getExhaustion() + object.execute(environment, context, Number.class).floatValue());
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        player.execute(context, Player.class).setExhaustion(0);
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        player.execute(environment, context, Player.class).setExhaustion(0);
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
 
-        player.setExhaustion(player.getExhaustion() - object.execute(context, Number.class).floatValue());
+        player.setExhaustion(player.getExhaustion() - object.execute(environment, context, Number.class).floatValue());
     }
 
     @Override
-    public void removeAll(@Nullable Context context, @NotNull PsiElement<?> object) {
-        player.execute(context, Player.class).setExhaustion(0);
+    public void removeAll(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        player.execute(environment, context, Player.class).setExhaustion(0);
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        player.execute(context, Player.class).setExhaustion(0);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        player.execute(environment, context, Player.class).setExhaustion(0);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        player.execute(context, Player.class).setExhaustion(object.execute(context, Number.class).floatValue());
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        player.execute(environment, context, Player.class).setExhaustion(object.execute(environment, context, Number.class).floatValue());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiExperienceExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiExperienceExpressionImpl.java
@@ -7,6 +7,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiExperienceExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -32,7 +33,7 @@ public class PsiExperienceExpressionImpl extends PsiExperienceExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Experience expression can only be used inside events", lineNumber);
         }
@@ -50,7 +51,7 @@ public class PsiExperienceExpressionImpl extends PsiExperienceExpression {
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Experience expression can only be used inside events", lineNumber);
         }
@@ -65,13 +66,13 @@ public class PsiExperienceExpressionImpl extends PsiExperienceExpression {
         }
 
         ExperienceOrbSpawnEvent experienceOrbSpawnEvent = (ExperienceOrbSpawnEvent) event;
-        int newXp = experienceOrbSpawnEvent.getXp() + object.execute(context, Number.class).intValue();
+        int newXp = experienceOrbSpawnEvent.getXp() + object.execute(environment, context, Number.class).intValue();
 
         experienceOrbSpawnEvent.setXp(Math.max(0, newXp));
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Experience expression can only be used inside events", lineNumber);
         }
@@ -86,18 +87,18 @@ public class PsiExperienceExpressionImpl extends PsiExperienceExpression {
         }
 
         ExperienceOrbSpawnEvent experienceOrbSpawnEvent = (ExperienceOrbSpawnEvent) event;
-        int newXp = experienceOrbSpawnEvent.getXp() - object.execute(context, Number.class).intValue();
+        int newXp = experienceOrbSpawnEvent.getXp() - object.execute(environment, context, Number.class).intValue();
 
         experienceOrbSpawnEvent.setXp(Math.max(0, newXp));
     }
 
     @Override
-    public void removeAll(@Nullable Context context, @NotNull PsiElement<?> object) {
-        remove(context, object);
+    public void removeAll(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        remove(environment, context, object);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Experience expression can only be used inside events", lineNumber);
         }
@@ -113,7 +114,7 @@ public class PsiExperienceExpressionImpl extends PsiExperienceExpression {
 
         ExperienceOrbSpawnEvent experienceOrbSpawnEvent = (ExperienceOrbSpawnEvent) event;
 
-        experienceOrbSpawnEvent.setXp(Math.max(0, object.execute(context, Number.class).intValue()));
+        experienceOrbSpawnEvent.setXp(Math.max(0, object.execute(environment, context, Number.class).intValue()));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFakeMaxPlayersExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFakeMaxPlayersExpressionImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiFakeMaxPlayersExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.server.ServerListPingEvent;
@@ -34,39 +35,39 @@ public class PsiFakeMaxPlayersExpressionImpl extends PsiFakeMaxPlayersExpression
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return forceGetServerListPingEvent(context).getMaxPlayers();
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         ServerListPingEvent serverListPingEvent = forceGetServerListPingEvent(context);
-        int newMaxPlayers = serverListPingEvent.getMaxPlayers() + object.execute(context, Number.class).intValue();
+        int newMaxPlayers = serverListPingEvent.getMaxPlayers() + object.execute(environment, context, Number.class).intValue();
 
         serverListPingEvent.setMaxPlayers(newMaxPlayers);
     }
 
     @Override
-    public void delete(@Nullable Context context) {
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         forceGetServerListPingEvent(context).setMaxPlayers(Bukkit.getMaxPlayers());
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         ServerListPingEvent serverListPingEvent = forceGetServerListPingEvent(context);
-        int newMaxPlayers = serverListPingEvent.getMaxPlayers() - object.execute(context, Number.class).intValue();
+        int newMaxPlayers = serverListPingEvent.getMaxPlayers() - object.execute(environment, context, Number.class).intValue();
 
         serverListPingEvent.setMaxPlayers(newMaxPlayers);
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        forceGetServerListPingEvent(context).setMaxPlayers(object.execute(context, Number.class).intValue());
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        forceGetServerListPingEvent(context).setMaxPlayers(object.execute(environment, context, Number.class).intValue());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFakeOnlinePlayerCountExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFakeOnlinePlayerCountExpressionImpl.java
@@ -8,6 +8,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiFakeOnlinePlayerCountExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.server.ServerListPingEvent;
@@ -35,7 +36,7 @@ public class PsiFakeOnlinePlayerCountExpressionImpl extends PsiFakeOnlinePlayerC
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Fake online player count expression can only be executed from events",
                 lineNumber);
@@ -52,32 +53,32 @@ public class PsiFakeOnlinePlayerCountExpressionImpl extends PsiFakeOnlinePlayerC
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         PaperServerListPingEvent pingEvent = forceGetPingEvent(context);
 
-        pingEvent.setNumPlayers(pingEvent.getNumPlayers() + object.execute(context, Number.class).intValue());
+        pingEvent.setNumPlayers(pingEvent.getNumPlayers() + object.execute(environment, context, Number.class).intValue());
     }
 
     @Override
-    public void delete(@Nullable Context context) {
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         forceGetPingEvent(context).setNumPlayers(Bukkit.getOnlinePlayers().size());
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         PaperServerListPingEvent pingEvent = forceGetPingEvent(context);
 
-        pingEvent.setNumPlayers(pingEvent.getNumPlayers() - object.execute(context, Number.class).intValue());
+        pingEvent.setNumPlayers(pingEvent.getNumPlayers() - object.execute(environment, context, Number.class).intValue());
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        forceGetPingEvent(context).setNumPlayers(object.execute(context, Number.class).intValue());
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        forceGetPingEvent(context).setNumPlayers(object.execute(environment, context, Number.class).intValue());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFinalDamageExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFinalDamageExpressionImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiFinalDamageExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.event.Event;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.jetbrains.annotations.Contract;
@@ -31,7 +32,7 @@ public class PsiFinalDamageExpressionImpl extends PsiFinalDamageExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Double executeImpl(@Nullable Context context) {
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Expression can only be executed from events", lineNumber);
         }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFlyModeExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFlyModeExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiFlyModeExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -30,18 +31,18 @@ public class PsiFlyModeExpressionImpl extends PsiFlyModeExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return player.execute(context, Player.class).getAllowFlight();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return player.execute(environment, context, Player.class).getAllowFlight();
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        player.execute(context, Player.class).setAllowFlight(false);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        player.execute(environment, context, Player.class).setAllowFlight(false);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        player.execute(context, Player.class).setAllowFlight(object.execute(context, Boolean.class));
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        player.execute(environment, context, Player.class).setAllowFlight(object.execute(environment, context, Boolean.class));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFoodLevelExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiFoodLevelExpressionImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiFoodLevelExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
@@ -33,37 +34,37 @@ public class PsiFoodLevelExpressionImpl extends PsiFoodLevelExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return forceGetPlayer(context).getFoodLevel() / 2.0;
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return forceGetPlayer(environment, context).getFoodLevel() / 2.0;
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = forceGetPlayer(context);
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = forceGetPlayer(environment, context);
 
-        player.setFoodLevel(player.getFoodLevel() + (int) (object.execute(context, Number.class).doubleValue() * 2));
+        player.setFoodLevel(player.getFoodLevel() + (int) (object.execute(environment, context, Number.class).doubleValue() * 2));
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        forceGetPlayer(context).setFoodLevel(0);
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        forceGetPlayer(environment, context).setFoodLevel(0);
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = forceGetPlayer(context);
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = forceGetPlayer(environment, context);
 
-        player.setFoodLevel(player.getFoodLevel() - (int) (object.execute(context, Number.class).doubleValue() * 2));
+        player.setFoodLevel(player.getFoodLevel() - (int) (object.execute(environment, context, Number.class).doubleValue() * 2));
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        forceGetPlayer(context).setFoodLevel(20);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        forceGetPlayer(environment, context).setFoodLevel(20);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        forceGetPlayer(context).setFoodLevel((int) (object.execute(context, Number.class).doubleValue() * 2));
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        forceGetPlayer(environment, context).setFoodLevel((int) (object.execute(environment, context, Number.class).doubleValue() * 2));
     }
 
     /**
@@ -76,7 +77,7 @@ public class PsiFoodLevelExpressionImpl extends PsiFoodLevelExpression {
      */
     @NotNull
     @Contract(pure = true)
-    private Player forceGetPlayer(@Nullable Context context) {
+    private Player forceGetPlayer(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         Player player = null;
 
         if (this.player == null && context != null) {
@@ -86,7 +87,7 @@ public class PsiFoodLevelExpressionImpl extends PsiFoodLevelExpression {
                 player = (Player) commandSender;
             }
         } else if (this.player != null) {
-            player = this.player.execute(context, Player.class);
+            player = this.player.execute(environment, context, Player.class);
         }
 
         if (player == null) {

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiGlidingStateExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiGlidingStateExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiGlidingStateExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.LivingEntity;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -29,18 +30,18 @@ public class PsiGlidingStateExpressionImpl extends PsiGlidingStateExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return livingEntity.execute(context, LivingEntity.class).isGliding();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return livingEntity.execute(environment, context, LivingEntity.class).isGliding();
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        livingEntity.execute(context, LivingEntity.class).setGliding(false);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        livingEntity.execute(environment, context, LivingEntity.class).setGliding(false);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        livingEntity.execute(context, LivingEntity.class).setGliding(object.execute(context, Boolean.class));
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        livingEntity.execute(environment, context, LivingEntity.class).setGliding(object.execute(environment, context, Boolean.class));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiGlowingExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiGlowingExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiGlowingExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -24,18 +25,18 @@ public class PsiGlowingExpressionImpl extends PsiGlowingExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return entity.execute(context, Entity.class).isGlowing();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return entity.execute(environment, context, Entity.class).isGlowing();
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        entity.execute(context, Entity.class).setGlowing(false);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        entity.execute(environment, context, Entity.class).setGlowing(false);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        entity.execute(context, Entity.class).setGlowing(object.execute(context, Boolean.class));
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        entity.execute(environment, context, Entity.class).setGlowing(object.execute(environment, context, Boolean.class));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiGravityExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiGravityExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiGravityExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -30,18 +31,18 @@ public class PsiGravityExpressionImpl extends PsiGravityExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return entity.execute(context, Entity.class).hasGravity();
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return entity.execute(environment, context, Entity.class).hasGravity();
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        entity.execute(context, Entity.class).setGravity(true);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        entity.execute(environment, context, Entity.class).setGravity(true);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        entity.execute(context, Entity.class).setGravity(object.execute(context, Boolean.class));
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        entity.execute(environment, context, Entity.class).setGravity(object.execute(environment, context, Boolean.class));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiHealthExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiHealthExpressionImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiHealthExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.attribute.Attributable;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
@@ -33,32 +34,32 @@ public class PsiHealthExpressionImpl extends PsiHealthExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return damageable.execute(context, Damageable.class).getHealth() / 2.0;
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return damageable.execute(environment, context, Damageable.class).getHealth() / 2.0;
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Damageable damageable = this.damageable.execute(context, Damageable.class);
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Damageable damageable = this.damageable.execute(environment, context, Damageable.class);
 
-        damageable.setHealth(damageable.getHealth() + object.execute(context, Number.class).doubleValue() * 2.0);
+        damageable.setHealth(damageable.getHealth() + object.execute(environment, context, Number.class).doubleValue() * 2.0);
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        damageable.execute(context, Damageable.class).setHealth(0);
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        damageable.execute(environment, context, Damageable.class).setHealth(0);
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Damageable damageable = this.damageable.execute(context, Damageable.class);
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Damageable damageable = this.damageable.execute(environment, context, Damageable.class);
 
-        damageable.setHealth(damageable.getHealth() - object.execute(context, Number.class).doubleValue() * 2.0);
+        damageable.setHealth(damageable.getHealth() - object.execute(environment, context, Number.class).doubleValue() * 2.0);
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        Object object = damageable.execute(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = damageable.execute(environment, context);
 
         if (!(object instanceof Attributable) || !(object instanceof Damageable)) {
             throw new ExecutionException("Object must be both an Attributable and a Damageable", lineNumber);
@@ -74,10 +75,10 @@ public class PsiHealthExpressionImpl extends PsiHealthExpression {
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        double health = object.execute(context, Number.class).doubleValue();
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        double health = object.execute(environment, context, Number.class).doubleValue();
 
-        damageable.execute(context, Damageable.class).setHealth(health * 2.0);
+        damageable.execute(environment, context, Damageable.class).setHealth(health * 2.0);
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiHiddenPlayersExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiHiddenPlayersExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiHiddenPlayersExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -32,8 +33,8 @@ public class PsiHiddenPlayersExpressionImpl extends PsiHiddenPlayersExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Collection<?> executeImpl(@Nullable Context context) {
-        return player.execute(context, Player.class).spigot().getHiddenPlayers();
+    protected Collection<?> executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return player.execute(environment, context, Player.class).spigot().getHiddenPlayers();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiHoverListExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiHoverListExpressionImpl.java
@@ -8,6 +8,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiHoverListExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -41,7 +42,7 @@ public class PsiHoverListExpressionImpl extends PsiHoverListExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Collection<Text> executeImpl(@Nullable Context context) {
+    protected Collection<Text> executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("This expression can only be used inside events", lineNumber);
         }
@@ -61,7 +62,7 @@ public class PsiHoverListExpressionImpl extends PsiHoverListExpression {
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("This expression can only be used inside events", lineNumber);
         }
@@ -72,11 +73,11 @@ public class PsiHoverListExpressionImpl extends PsiHoverListExpression {
             throw new ExecutionException("This expression can only be used inside ping events", lineNumber);
         }
 
-        ((PaperServerListPingEvent) event).getPlayerSample().add(forceGetProfile(context, object));
+        ((PaperServerListPingEvent) event).getPlayerSample().add(forceGetProfile(environment, context, object));
     }
 
     @Override
-    public void delete(@Nullable Context context) {
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("This expression can only be used inside events", lineNumber);
         }
@@ -91,7 +92,7 @@ public class PsiHoverListExpressionImpl extends PsiHoverListExpression {
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("This expression can only be used inside events", lineNumber);
         }
@@ -102,16 +103,16 @@ public class PsiHoverListExpressionImpl extends PsiHoverListExpression {
             throw new ExecutionException("This expression can only be used inside ping events", lineNumber);
         }
 
-        ((PaperServerListPingEvent) event).getPlayerSample().remove(forceGetProfile(context, object));
+        ((PaperServerListPingEvent) event).getPlayerSample().remove(forceGetProfile(environment, context, object));
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("This expression can only be used inside events", lineNumber);
         }
@@ -125,7 +126,7 @@ public class PsiHoverListExpressionImpl extends PsiHoverListExpression {
         List<PlayerProfile> playerSample = ((PaperServerListPingEvent) event).getPlayerSample();
 
         playerSample.clear();
-        playerSample.add(forceGetProfile(context, object));
+        playerSample.add(forceGetProfile(environment, context, object));
     }
 
     /**
@@ -139,7 +140,7 @@ public class PsiHoverListExpressionImpl extends PsiHoverListExpression {
      */
     @NotNull
     @Contract(pure = true)
-    private PlayerProfile forceGetProfile(@Nullable Context context, @NotNull PsiElement<?> object) {
+    private PlayerProfile forceGetProfile(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("This expression can only be used inside events", lineNumber);
         }
@@ -150,7 +151,7 @@ public class PsiHoverListExpressionImpl extends PsiHoverListExpression {
             throw new ExecutionException("This expression can only be used inside ping events", lineNumber);
         }
 
-        Object obj = object.execute(context);
+        Object obj = object.execute(environment, context);
 
         if (obj instanceof Player) {
             return Bukkit.createProfile(((Player) obj).getUniqueId(), ((Player) obj).getName());

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiIPExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiIPExpressionImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiIPExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
@@ -39,7 +40,7 @@ public class PsiIPExpressionImpl extends PsiIPExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         InetAddress inetAddress;
 
         if (player == null) {
@@ -57,7 +58,7 @@ public class PsiIPExpressionImpl extends PsiIPExpression {
                 throw new ExecutionException("You need Paper to execute this expression from a ping event", lineNumber);
             }
         } else {
-            InetSocketAddress address = player.execute(context, Player.class).getAddress();
+            InetSocketAddress address = player.execute(environment, context, Player.class).getAddress();
 
             if (address == null) {
                 throw new ExecutionException("Could not find address for player", lineNumber);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiJoinMessageExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiJoinMessageExpressionImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiJoinMessageExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -33,7 +34,7 @@ public class PsiJoinMessageExpressionImpl extends PsiJoinMessageExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Join message can only be retrieved from an event", lineNumber);
         }
@@ -48,7 +49,7 @@ public class PsiJoinMessageExpressionImpl extends PsiJoinMessageExpression {
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Join message can only be retrieved from an event", lineNumber);
         }
@@ -59,7 +60,7 @@ public class PsiJoinMessageExpressionImpl extends PsiJoinMessageExpression {
             throw new ExecutionException("Join message can only be retrieved from a join event", lineNumber);
         }
 
-        ((PlayerJoinEvent) event).setJoinMessage(object.execute(context, Text.class).toString());
+        ((PlayerJoinEvent) event).setJoinMessage(object.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLanguageExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLanguageExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiLanguageExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
@@ -31,8 +32,8 @@ public class PsiLanguageExpressionImpl extends PsiLanguageExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
-        return Text.parseLiteral(player.execute(context, Player.class).getLocale());
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Text.parseLiteral(player.execute(environment, context, Player.class).getLocale());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLeashHolderExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLeashHolderExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiLeashHolderExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.jetbrains.annotations.Contract;
@@ -31,8 +32,8 @@ public class PsiLeashHolderExpressionImpl extends PsiLeashHolderExpression {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Entity executeImpl(@Nullable Context context) {
-        LivingEntity entity = this.entity.execute(context, LivingEntity.class);
+    protected Entity executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        LivingEntity entity = this.entity.execute(environment, context, LivingEntity.class);
 
         return entity.isLeashed() ? entity.getLeashHolder() : null;
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLeaveMessageExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLeaveMessageExpressionImpl.java
@@ -6,6 +6,7 @@ import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiLeaveMessageExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -33,7 +34,7 @@ public class PsiLeaveMessageExpressionImpl extends PsiLeaveMessageExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Leave message expression can only be executed from an event", lineNumber);
         }
@@ -49,7 +50,7 @@ public class PsiLeaveMessageExpressionImpl extends PsiLeaveMessageExpression {
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Leave message expression can only be executed from an event", lineNumber);
         }
@@ -61,7 +62,7 @@ public class PsiLeaveMessageExpressionImpl extends PsiLeaveMessageExpression {
                 lineNumber);
         }
 
-        ((PlayerQuitEvent) event).setQuitMessage(object.execute(context, Text.class).toString());
+        ((PlayerQuitEvent) event).setQuitMessage(object.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLevelExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLevelExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiLevelExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -29,37 +30,37 @@ public class PsiLevelExpressionImpl extends PsiLevelExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
-        return this.player.execute(context, Player.class).getLevel();
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return this.player.execute(environment, context, Player.class).getLevel();
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
 
-        player.setLevel(player.getLevel() + object.execute(context, Integer.class));
+        player.setLevel(player.getLevel() + object.execute(environment, context, Integer.class));
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        this.player.execute(context, Player.class).setLevel(0);
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        this.player.execute(environment, context, Player.class).setLevel(0);
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
 
-        player.setLevel(player.getLevel() - object.execute(context, Integer.class));
+        player.setLevel(player.getLevel() - object.execute(environment, context, Integer.class));
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(null);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        this.player.execute(context, Player.class).setLevel(object.execute(context, Integer.class));
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        this.player.execute(environment, context, Player.class).setLevel(object.execute(environment, context, Integer.class));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLevelProgressExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLevelProgressExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiLevelProgressExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -30,42 +31,42 @@ public class PsiLevelProgressExpressionImpl extends PsiLevelProgressExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Float executeImpl(@Nullable Context context) {
-        return player.execute(context, Player.class).getExp();
+    protected Float executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return player.execute(environment, context, Player.class).getExp();
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
-        float exp = player.getExp() + object.execute(context, Number.class).floatValue();
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
+        float exp = player.getExp() + object.execute(environment, context, Number.class).floatValue();
 
         player.setLevel(player.getLevel() + (int) Math.floor(exp));
         player.setExp(player.getExp() + exp % 1);
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        this.player.execute(context, Player.class).setExp(0);
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        this.player.execute(environment, context, Player.class).setExp(0);
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
-        float exp = player.getExp() - object.execute(context, Number.class).floatValue();
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
+        float exp = player.getExp() - object.execute(environment, context, Number.class).floatValue();
 
         player.setLevel(player.getLevel() + (int) Math.floor(exp));
         player.setExp(player.getExp() + exp % 1);
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
-        float exp = object.execute(context, Number.class).floatValue();
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
+        float exp = object.execute(environment, context, Number.class).floatValue();
 
         player.setLevel(player.getLevel() + (int) Math.floor(exp));
         player.setExp(player.getExp() + exp % 1);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLoadedServerIconExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiLoadedServerIconExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.effect.PsiLoadServerIconEffect;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiLoadedServerIconExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.TemporaryCache;
 import org.bukkit.util.CachedServerIcon;
 import org.jetbrains.annotations.Contract;
@@ -29,7 +30,7 @@ public class PsiLoadedServerIconExpressionImpl extends PsiLoadedServerIconExpres
     @Nullable
     @Contract(pure = true)
     @Override
-    protected CachedServerIcon executeImpl(@Nullable Context context) {
+    protected CachedServerIcon executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return TemporaryCache.get("last-server-icon");
     }
 

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiMaxHealthExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiMaxHealthExpressionImpl.java
@@ -4,6 +4,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiMaxHealthExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.attribute.Attributable;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
@@ -33,8 +34,8 @@ public class PsiMaxHealthExpressionImpl extends PsiMaxHealthExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        Attributable attributable = livingEntity.execute(context, Attributable.class);
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Attributable attributable = livingEntity.execute(environment, context, Attributable.class);
         AttributeInstance attribute = attributable.getAttribute(Attribute.GENERIC_MAX_HEALTH);
 
         if (attribute == null) {
@@ -45,32 +46,32 @@ public class PsiMaxHealthExpressionImpl extends PsiMaxHealthExpression {
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Attributable attributable = livingEntity.execute(context, Attributable.class);
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Attributable attributable = livingEntity.execute(environment, context, Attributable.class);
         AttributeInstance attribute = attributable.getAttribute(Attribute.GENERIC_MAX_HEALTH);
 
         if (attribute == null) {
             throw new ExecutionException("Entity does not have a maximum health", lineNumber);
         }
 
-        attribute.setBaseValue(attribute.getBaseValue() + object.execute(context, Number.class).doubleValue() * 2);
+        attribute.setBaseValue(attribute.getBaseValue() + object.execute(environment, context, Number.class).doubleValue() * 2);
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Attributable attributable = livingEntity.execute(context, Attributable.class);
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Attributable attributable = livingEntity.execute(environment, context, Attributable.class);
         AttributeInstance attribute = attributable.getAttribute(Attribute.GENERIC_MAX_HEALTH);
 
         if (attribute == null) {
             throw new ExecutionException("Entity does not have a maximum health", lineNumber);
         }
 
-        attribute.setBaseValue(attribute.getBaseValue() - object.execute(context, Number.class).doubleValue() * 2);
+        attribute.setBaseValue(attribute.getBaseValue() - object.execute(environment, context, Number.class).doubleValue() * 2);
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        Attributable attributable = livingEntity.execute(context, Attributable.class);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Attributable attributable = livingEntity.execute(environment, context, Attributable.class);
         AttributeInstance attribute = attributable.getAttribute(Attribute.GENERIC_MAX_HEALTH);
 
         if (attribute == null) {
@@ -81,15 +82,15 @@ public class PsiMaxHealthExpressionImpl extends PsiMaxHealthExpression {
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Attributable attributable = livingEntity.execute(context, Attributable.class);
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Attributable attributable = livingEntity.execute(environment, context, Attributable.class);
         AttributeInstance attribute = attributable.getAttribute(Attribute.GENERIC_MAX_HEALTH);
 
         if (attribute == null) {
             throw new ExecutionException("Entity does not have a maximum health", lineNumber);
         }
 
-        attribute.setBaseValue(object.execute(context, Number.class).doubleValue() * 2);
+        attribute.setBaseValue(object.execute(environment, context, Number.class).doubleValue() * 2);
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiMeExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiMeExpressionImpl.java
@@ -5,6 +5,7 @@ import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.context.ExecuteContext;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiMeExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +32,7 @@ public class PsiMeExpressionImpl extends PsiMeExpression {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected CommandSender executeImpl(@Nullable Context context) {
+    protected CommandSender executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof ExecuteContext))
             throw new ExecutionException("This expression can only be used inside execute commands", lineNumber);
 

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiMinecraftVersionExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiMinecraftVersionExpressionImpl.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiMinecraftVersionExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Contract;
@@ -24,13 +25,13 @@ public class PsiMinecraftVersionExpressionImpl extends PsiMinecraftVersionExpres
     private PsiMinecraftVersionExpressionImpl(int lineNumber) {
         super(lineNumber);
 
-        preComputed = executeImpl(null);
+        preComputed = executeImpl(null, null);
     }
 
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         String bukkitVersion = Bukkit.getBukkitVersion();
 
         return Text.parseLiteral(bukkitVersion.substring(0, bukkitVersion.indexOf('-')));

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiOfflinePlayersExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiOfflinePlayersExpressionImpl.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiOfflinePlayersExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.Contract;
@@ -29,7 +30,7 @@ public class PsiOfflinePlayersExpressionImpl extends PsiOfflinePlayersExpression
     @NotNull
     @Contract(pure = true)
     @Override
-    protected OfflinePlayer[] executeImpl(@Nullable Context context) {
+    protected OfflinePlayer[] executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return Bukkit.getOfflinePlayers();
     }
 

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPassengersExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPassengersExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiPassengersExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -31,24 +32,24 @@ public class PsiPassengersExpressionImpl extends PsiPassengersExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected List<Entity> executeImpl(@Nullable Context context) {
-        return entity.execute(context, Entity.class).getPassengers();
+    protected List<Entity> executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return entity.execute(environment, context, Entity.class).getPassengers();
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        entity.execute(context, Entity.class).getPassengers().add(object.execute(context, Entity.class));
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        entity.execute(environment, context, Entity.class).getPassengers().add(object.execute(environment, context, Entity.class));
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        entity.execute(context, Entity.class).eject();
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        entity.execute(environment, context, Entity.class).eject();
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Entity entity = this.entity.execute(context, Entity.class);
-        Entity searchingEntity = object.execute(context, Entity.class);
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Entity entity = this.entity.execute(environment, context, Entity.class);
+        Entity searchingEntity = object.execute(environment, context, Entity.class);
 
         entity.getPassengers().stream()
             .filter(passenger -> passenger.equals(searchingEntity))
@@ -56,21 +57,21 @@ public class PsiPassengersExpressionImpl extends PsiPassengersExpression {
     }
 
     @Override
-    public void removeAll(@Nullable Context context, @NotNull PsiElement<?> object) {
-        remove(context, object);
+    public void removeAll(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        remove(environment, context, object);
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Entity entity = this.entity.execute(context, Entity.class);
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Entity entity = this.entity.execute(environment, context, Entity.class);
 
         entity.eject();
-        entity.addPassenger(object.execute(context, Entity.class));
+        entity.addPassenger(object.execute(environment, context, Entity.class));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPermissionsExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPermissionsExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiPermissionsExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.jetbrains.annotations.Contract;
@@ -30,8 +31,8 @@ public class PsiPermissionsExpressionImpl extends PsiPermissionsExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected String[] executeImpl(@Nullable Context context) {
-        return player.execute(context, Player.class).getEffectivePermissions().stream()
+    protected String[] executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return player.execute(environment, context, Player.class).getEffectivePermissions().stream()
             .map(PermissionAttachmentInfo::getPermission)
             .toArray(String[]::new);
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPingExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPingExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiPingExpression;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -29,8 +30,8 @@ public class PsiPingExpressionImpl extends PsiPingExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
-        return player.execute(context, Player.class).spigot().getPing();
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return player.execute(environment, context, Player.class).spigot().getPing();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPlayerListFooterExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPlayerListFooterExpressionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiPlayerListFooterExpression;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
@@ -30,23 +31,23 @@ public class PsiPlayerListFooterExpressionImpl extends PsiPlayerListFooterExpres
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
-        return Text.parseNullable(player.execute(context, Player.class).getPlayerListFooter());
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Text.parseNullable(player.execute(environment, context, Player.class).getPlayerListFooter());
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        player.execute(context, Player.class).setPlayerListFooter("");
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        player.execute(environment, context, Player.class).setPlayerListFooter("");
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        player.execute(context, Player.class).setPlayerListFooter(object.execute(context, Text.class).toString());
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        player.execute(environment, context, Player.class).setPlayerListFooter(object.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPlayerListHeaderExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiPlayerListHeaderExpressionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiPlayerListHeaderExpression;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
@@ -30,23 +31,23 @@ public class PsiPlayerListHeaderExpressionImpl extends PsiPlayerListHeaderExpres
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
-        return Text.parseNullable(player.execute(context, Player.class).getPlayerListHeader());
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Text.parseNullable(player.execute(environment, context, Player.class).getPlayerListHeader());
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        player.execute(context, Player.class).setPlayerListHeader("");
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        player.execute(environment, context, Player.class).setPlayerListHeader("");
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        player.execute(context, Player.class).setPlayerListHeader(object.execute(context, Text.class).toString());
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        player.execute(environment, context, Player.class).setPlayerListHeader(object.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiProtocolVersionExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiProtocolVersionExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import com.github.stefvanschie.quickskript.bukkit.context.EventContextImpl;
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
@@ -32,7 +33,7 @@ public class PsiProtocolVersionExpressionImpl extends PsiProtocolVersionExpressi
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Protocol version expression can only be executed from an event", lineNumber);
         }
@@ -48,7 +49,7 @@ public class PsiProtocolVersionExpressionImpl extends PsiProtocolVersionExpressi
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Protocol version expression can only be executed from an event", lineNumber);
         }
@@ -60,7 +61,7 @@ public class PsiProtocolVersionExpressionImpl extends PsiProtocolVersionExpressi
                 lineNumber);
         }
 
-        ((PaperServerListPingEvent) event).setProtocolVersion(object.execute(context, Integer.class));
+        ((PaperServerListPingEvent) event).setProtocolVersion(object.execute(environment, context, Integer.class));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiRealMaxPlayersExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiRealMaxPlayersExpressionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiRealMaxPlayersExpression;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Contract;
@@ -28,7 +29,7 @@ public class PsiRealMaxPlayersExpressionImpl extends PsiRealMaxPlayersExpression
     @Override
     @Contract(pure = true)
     @NotNull
-    protected Integer executeImpl(@Nullable Context context) {
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return Bukkit.getMaxPlayers();
     }
 

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiRealOnlinePlayerCountExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiRealOnlinePlayerCountExpressionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiRealOnlinePlayerCountExpression;
 import org.bukkit.Bukkit;
 import org.jetbrains.annotations.Contract;
@@ -27,7 +28,7 @@ public class PsiRealOnlinePlayerCountExpressionImpl extends PsiRealOnlinePlayerC
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return Bukkit.getOnlinePlayers().size();
     }
 

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiSaturationExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiSaturationExpressionImpl.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.bukkit.context.ContextImpl;
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiSaturationExpression;
@@ -32,43 +33,44 @@ public class PsiSaturationExpressionImpl extends PsiSaturationExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Float executeImpl(@Nullable Context context) {
-        return forceGetPlayer(context).getSaturation();
+    protected Float executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return forceGetPlayer(environment, context).getSaturation();
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = forceGetPlayer(context);
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = forceGetPlayer(environment, context);
 
-        player.setSaturation(player.getSaturation() + object.execute(context, Number.class).floatValue());
+        player.setSaturation(player.getSaturation() + object.execute(environment, context, Number.class).floatValue());
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        forceGetPlayer(context).setSaturation(0);
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        forceGetPlayer(environment, context).setSaturation(0);
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = forceGetPlayer(context);
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = forceGetPlayer(environment, context);
 
-        player.setSaturation(player.getSaturation() - object.execute(context, Number.class).floatValue());
+        player.setSaturation(player.getSaturation() - object.execute(environment, context, Number.class).floatValue());
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        forceGetPlayer(context).setSaturation(object.execute(context, Number.class).floatValue());
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        forceGetPlayer(environment, context).setSaturation(object.execute(environment, context, Number.class).floatValue());
     }
 
     /**
      * Derives a player from both {@link #player} and the provided context. This will throw an
      * {@link ExecutionException} when no player could be found.
      *
+     * @param environment the environment for looking for the player
      * @param context the context for looking for the player
      * @return the player
      * @since 0.1.0
@@ -76,7 +78,7 @@ public class PsiSaturationExpressionImpl extends PsiSaturationExpression {
      */
     @NotNull
     @Contract(pure = true)
-    private Player forceGetPlayer(@Nullable Context context) {
+    private Player forceGetPlayer(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (this.player == null && context != null) {
             CommandSender sender = ((ContextImpl) context).getCommandSender();
 
@@ -88,7 +90,7 @@ public class PsiSaturationExpressionImpl extends PsiSaturationExpression {
         }
 
         if (this.player != null) {
-            return this.player.execute(context, Player.class);
+            return this.player.execute(environment, context, Player.class);
         }
 
         throw new ExecutionException("Implicit player can only be acquired with context", lineNumber);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiScoreboardTagsExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiScoreboardTagsExpressionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiScoreboardTagsExpression;
 import com.github.stefvanschie.quickskript.core.psi.util.PsiCollection;
@@ -34,47 +35,47 @@ public class PsiScoreboardTagsExpressionImpl extends PsiScoreboardTagsExpression
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Set<Text> executeImpl(@Nullable Context context) {
-        return entity.execute(context, Entity.class).getScoreboardTags().stream()
+    protected Set<Text> executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return entity.execute(environment, context, Entity.class).getScoreboardTags().stream()
             .map(Text::parseLiteral)
             .collect(Collectors.toSet());
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Entity entity = this.entity.execute(context, Entity.class);
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Entity entity = this.entity.execute(environment, context, Entity.class);
 
-        PsiCollection.toStreamForgiving(object.execute(context))
+        PsiCollection.toStreamForgiving(object.execute(environment, context))
             .map(Object::toString)
             .forEach(entity::addScoreboardTag);
     }
 
     @Override
-    public void delete(@Nullable Context context) {
-        entity.execute(context, Entity.class).getScoreboardTags().clear();
+    public void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        entity.execute(environment, context, Entity.class).getScoreboardTags().clear();
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Entity entity = this.entity.execute(context, Entity.class);
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Entity entity = this.entity.execute(environment, context, Entity.class);
 
-        PsiCollection.toStreamForgiving(object.execute(context))
+        PsiCollection.toStreamForgiving(object.execute(environment, context))
             .map(Object::toString)
             .forEach(entity::removeScoreboardTag);
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        delete(context);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        delete(environment, context);
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Entity entity = this.entity.execute(context, Entity.class);
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Entity entity = this.entity.execute(environment, context, Entity.class);
 
         entity.getScoreboardTags().clear();
 
-        PsiCollection.toStreamForgiving(object.execute(context))
+        PsiCollection.toStreamForgiving(object.execute(environment, context))
             .map(Object::toString)
             .forEach(entity::addScoreboardTag);
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiShownServerIconExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiShownServerIconExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import com.github.stefvanschie.quickskript.bukkit.context.EventContextImpl;
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
@@ -34,7 +35,7 @@ public class PsiShownServerIconExpressionImpl extends PsiShownServerIconExpressi
     @Nullable
     @Contract(pure = true)
     @Override
-    protected CachedServerIcon executeImpl(@Nullable Context context) {
+    protected CachedServerIcon executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("The shown server icon can only be retrieved in an event", lineNumber);
         }
@@ -49,7 +50,7 @@ public class PsiShownServerIconExpressionImpl extends PsiShownServerIconExpressi
     }
 
     @Override
-    public void reset(@Nullable Context context) {
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("The shown server icon can only be retrieved in an event", lineNumber);
         }
@@ -64,7 +65,7 @@ public class PsiShownServerIconExpressionImpl extends PsiShownServerIconExpressi
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("The shown server icon can only be retrieved in an event", lineNumber);
         }
@@ -75,7 +76,7 @@ public class PsiShownServerIconExpressionImpl extends PsiShownServerIconExpressi
             throw new ExecutionException("The shown server icon can only be retrieved in a ping event", lineNumber);
         }
 
-        ((PaperServerListPingEvent) event).setServerIcon(object.execute(context, CachedServerIcon.class));
+        ((PaperServerListPingEvent) event).setServerIcon(object.execute(environment, context, CachedServerIcon.class));
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiSpeedExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiSpeedExpressionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiSpeedExpression;
@@ -31,8 +32,8 @@ public class PsiSpeedExpressionImpl extends PsiSpeedExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Float executeImpl(@Nullable Context context) {
-        Player player = this.player.execute(context, Player.class);
+    protected Float executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Player player = this.player.execute(environment, context, Player.class);
 
         if (movementType == MovementType.WALKING) {
             return player.getWalkSpeed();
@@ -46,9 +47,9 @@ public class PsiSpeedExpressionImpl extends PsiSpeedExpression {
     }
 
     @Override
-    public void add(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
-        float delta = object.execute(context, Number.class).floatValue();
+    public void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
+        float delta = object.execute(environment, context, Number.class).floatValue();
 
         if (movementType == MovementType.WALKING) {
             player.setWalkSpeed((float) Math.max(-1.0, Math.min(1.0, player.getWalkSpeed() + delta)));
@@ -58,9 +59,9 @@ public class PsiSpeedExpressionImpl extends PsiSpeedExpression {
     }
 
     @Override
-    public void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
-        float delta = object.execute(context, Number.class).floatValue();
+    public void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
+        float delta = object.execute(environment, context, Number.class).floatValue();
 
         if (movementType == MovementType.WALKING) {
             player.setWalkSpeed((float) Math.max(-1.0, Math.min(1.0, player.getWalkSpeed() - delta)));
@@ -70,8 +71,8 @@ public class PsiSpeedExpressionImpl extends PsiSpeedExpression {
     }
 
     @Override
-    public void reset(@Nullable Context context) {
-        Player player = this.player.execute(context, Player.class);
+    public void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Player player = this.player.execute(environment, context, Player.class);
 
         if (movementType == MovementType.WALKING) {
             player.setWalkSpeed(0.2f);
@@ -81,9 +82,9 @@ public class PsiSpeedExpressionImpl extends PsiSpeedExpression {
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
-        Player player = this.player.execute(context, Player.class);
-        float value = object.execute(context, Number.class).floatValue();
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
+        Player player = this.player.execute(environment, context, Player.class);
+        float value = object.execute(environment, context, Number.class).floatValue();
 
         if (movementType == MovementType.WALKING) {
             player.setWalkSpeed((float) Math.max(-1.0, Math.min(1.0, value)));

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiTPSExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiTPSExpressionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiTPSExpression;
 import org.bukkit.Bukkit;
@@ -29,7 +30,7 @@ public class PsiTPSExpressionImpl extends PsiTPSExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected double[] executeImpl(@Nullable Context context) {
+    protected double[] executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (timespan == null) {
             return Bukkit.getTPS();
         }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiTamerExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiTamerExpressionImpl.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.bukkit.context.EventContextImpl;
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiTamerExpression;
@@ -32,7 +33,7 @@ public class PsiTamerExpressionImpl extends PsiTamerExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected AnimalTamer executeImpl(@Nullable Context context) {
+    protected AnimalTamer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Tamer expression can only be used in events", lineNumber);
         }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiVehicleExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiVehicleExpressionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.expression.PsiVehicleExpression;
 import org.bukkit.entity.Entity;
@@ -29,8 +30,8 @@ public class PsiVehicleExpressionImpl extends PsiVehicleExpression {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Entity executeImpl(@Nullable Context context) {
-        return entity.execute(context, Entity.class).getVehicle();
+    protected Entity executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return entity.execute(environment, context, Entity.class).getVehicle();
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiVersionStringExpressionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/expression/PsiVersionStringExpressionImpl.java
@@ -3,6 +3,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.expression;
 import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
 import com.github.stefvanschie.quickskript.bukkit.context.EventContextImpl;
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.context.EventContext;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
@@ -33,7 +34,7 @@ public class PsiVersionStringExpressionImpl extends PsiVersionStringExpression {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Version string expression can only be executed inside an event", lineNumber);
         }
@@ -49,7 +50,7 @@ public class PsiVersionStringExpressionImpl extends PsiVersionStringExpression {
     }
 
     @Override
-    public void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    public void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         if (!(context instanceof EventContext)) {
             throw new ExecutionException("Version string expression can only be executed inside an event", lineNumber);
         }
@@ -61,7 +62,7 @@ public class PsiVersionStringExpressionImpl extends PsiVersionStringExpression {
                 lineNumber);
         }
 
-        ((PaperServerListPingEvent) event).setVersion(object.execute(context, Text.class).toString());
+        ((PaperServerListPingEvent) event).setVersion(object.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/function/PsiLocationFunctionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/function/PsiLocationFunctionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.function.PsiLocationFunction;
 import org.bukkit.Location;
@@ -34,14 +35,14 @@ public class PsiLocationFunctionImpl extends PsiLocationFunction {
 
     @NotNull
     @Override
-    public Location executeImpl(@Nullable Context context) {
+    public Location executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return new Location(
-                world.execute(context, World.class),
-                x.execute(context, Number.class).doubleValue(),
-                y.execute(context, Number.class).doubleValue(),
-                z.execute(context, Number.class).doubleValue(),
-                yaw == null ? 0 : yaw.execute(context, Number.class).floatValue(),
-                pitch == null ? 0 : pitch.execute(context, Number.class).floatValue()
+                world.execute(environment, context, World.class),
+                x.execute(environment, context, Number.class).doubleValue(),
+                y.execute(environment, context, Number.class).doubleValue(),
+                z.execute(environment, context, Number.class).doubleValue(),
+                yaw == null ? 0 : yaw.execute(environment, context, Number.class).floatValue(),
+                pitch == null ? 0 : pitch.execute(environment, context, Number.class).floatValue()
         );
     }
 

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/function/PsiVectorFunctionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/function/PsiVectorFunctionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.function.PsiVectorFunction;
 import org.bukkit.util.Vector;
@@ -28,10 +29,10 @@ public class PsiVectorFunctionImpl extends PsiVectorFunction {
 
     @NotNull
     @Override
-    protected Vector executeImpl(@Nullable Context context) {
-        Number xResult = x.execute(context, Number.class);
-        Number yResult = y.execute(context, Number.class);
-        Number zResult = z.execute(context, Number.class);
+    protected Vector executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Number xResult = x.execute(environment, context, Number.class);
+        Number yResult = y.execute(environment, context, Number.class);
+        Number zResult = z.execute(environment, context, Number.class);
 
         return new Vector(xResult.doubleValue(), yResult.doubleValue(), zResult.doubleValue());
     }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/function/PsiWorldFunctionImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/function/PsiWorldFunctionImpl.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.bukkit.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.function.PsiWorldFunction;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
@@ -29,8 +30,8 @@ public class PsiWorldFunctionImpl extends PsiWorldFunction {
 
     @Nullable
     @Override
-    public World executeImpl(@Nullable Context context) {
-        return Bukkit.getWorld(parameter.execute(context, Text.class).toString());
+    public World executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Bukkit.getWorld(parameter.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/literal/PsiPlayerLiteralImpl.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/psi/literal/PsiPlayerLiteralImpl.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.bukkit.psi.literal;
 
 import com.github.stefvanschie.quickskript.bukkit.context.ContextImpl;
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.psi.literal.PsiPlayerLiteral;
 import org.bukkit.command.CommandSender;
@@ -22,7 +23,7 @@ public class PsiPlayerLiteralImpl extends PsiPlayerLiteral {
 
     @NotNull
     @Override
-    protected Player executeImpl(@Nullable Context context) {
+    protected Player executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (context == null) {
             throw new ExecutionException("Cannot find a player without a context", lineNumber);
         }

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/skript/SkriptCommandExecutor.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/skript/SkriptCommandExecutor.java
@@ -9,6 +9,7 @@ import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException
 import com.github.stefvanschie.quickskript.core.psi.section.PsiBaseSection;
 import com.github.stefvanschie.quickskript.core.skript.Skript;
 import com.github.stefvanschie.quickskript.core.skript.SkriptLoader;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -31,6 +32,12 @@ public class SkriptCommandExecutor implements CommandExecutor {
     private final Skript skript;
 
     /**
+     * The run environment this executor operates in
+     */
+    @NotNull
+    private final SkriptRunEnvironment environment;
+
+    /**
      * The elements that should get executed
      */
     @NotNull
@@ -47,13 +54,15 @@ public class SkriptCommandExecutor implements CommandExecutor {
      * part in a skript file.
      *
      * @param skript the source of this command executor code
+     * @param environment the environment this executor operates in
      * @param section the file section to load the elements from
      * @param executionTarget the group which can execute this command
      * @since 0.1.0
      */
-    SkriptCommandExecutor(@NotNull SkriptLoader skriptLoader, @NotNull Skript skript,
-        @NotNull SkriptFileSection section, @Nullable ExecutionTarget executionTarget) {
+    SkriptCommandExecutor(@NotNull SkriptLoader skriptLoader, @NotNull SkriptRunEnvironment environment,
+            @NotNull Skript skript, @NotNull SkriptFileSection section, @Nullable ExecutionTarget executionTarget) {
         this.skript = skript;
+        this.environment = environment;
         this.executionTarget = executionTarget;
         elements = new PsiBaseSection(skriptLoader, skript, section, CommandContext.class);
     }
@@ -65,7 +74,7 @@ public class SkriptCommandExecutor implements CommandExecutor {
         }
 
         try {
-            elements.execute(new CommandContextImpl(skript, sender));
+            elements.execute(environment, new CommandContextImpl(skript, sender));
         } catch (ExecutionException e) {
             QuickSkript.getInstance().getLogger().log(Level.SEVERE, "Error while executing skript:" +
                     e.getExtraInfo(skript), e);

--- a/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/skript/SkriptEventExecutor.java
+++ b/bukkit/src/main/java/com/github/stefvanschie/quickskript/bukkit/skript/SkriptEventExecutor.java
@@ -8,6 +8,7 @@ import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException
 import com.github.stefvanschie.quickskript.core.psi.section.PsiBaseSection;
 import com.github.stefvanschie.quickskript.core.skript.Skript;
 import com.github.stefvanschie.quickskript.core.skript.SkriptLoader;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,10 +22,16 @@ import java.util.logging.Level;
 public class SkriptEventExecutor {
 
     /**
-     * The skript this command belongs to
+     * The skript this event belongs to
      */
     @NotNull
     private final Skript skript;
+
+    /**
+     * The run environment this executor operates in
+     */
+    @NotNull
+    private final SkriptRunEnvironment environment;
 
     /**
      * The elements that should get executed
@@ -36,12 +43,14 @@ public class SkriptEventExecutor {
      * Constructs a new skript event.
      *
      * @param skript the source of this event handler code
+     * @param environment the environment this executor operates in
      * @param section the file section to load the elements from
      * @since 0.1.0
      */
-    SkriptEventExecutor(@NotNull SkriptLoader skriptLoader, @NotNull Skript skript,
-        @NotNull SkriptFileSection section) {
+    SkriptEventExecutor(@NotNull SkriptLoader skriptLoader, @NotNull SkriptRunEnvironment environment,
+            @NotNull Skript skript, @NotNull SkriptFileSection section) {
         this.skript = skript;
+        this.environment = environment;
         elements = new PsiBaseSection(skriptLoader, skript, section, EventContext.class);
     }
 
@@ -53,7 +62,7 @@ public class SkriptEventExecutor {
      */
     public void execute(@NotNull Event event) {
         try {
-            elements.execute(new EventContextImpl(skript, event));
+            elements.execute(environment, new EventContextImpl(skript, event));
         } catch (ExecutionException e) {
             QuickSkript.getInstance().getLogger().log(Level.SEVERE, "Error while executing:" +
                     e.getExtraInfo(skript), e);

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/file/alias/AliasFile.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/file/alias/AliasFile.java
@@ -5,7 +5,6 @@ import com.github.stefvanschie.quickskript.core.file.alias.exception.AliasFileRe
 import com.github.stefvanschie.quickskript.core.file.alias.exception.UndefinedAliasFileVariation;
 import com.github.stefvanschie.quickskript.core.file.alias.manager.AliasFileManager;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
-import com.github.stefvanschie.quickskript.core.pattern.exception.SkriptPatternParseException;
 import com.github.stefvanschie.quickskript.core.util.registry.ItemTypeRegistry;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/file/alias/AliasFileVariation.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/file/alias/AliasFileVariation.java
@@ -1,10 +1,8 @@
 package com.github.stefvanschie.quickskript.core.file.alias;
 
-import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.List;
 
 /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/PsiElement.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/PsiElement.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.core.psi;
 
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,19 +45,21 @@ public abstract class PsiElement<T> {
     /**
      * Returns a pre computed value if {@link #isPreComputed()} returns true otherwise executes this element.
      *
+     * @param environment the environment this code is being executed in, may be null if the code is expected to be pre computed
      * @param context the context this code is being executed in, may be null if the code is expected to be pre computed
      * @return the computed value which is null if the computation returned null
      * @since 0.1.0
      */
     @Nullable
-    public final T execute(@Nullable Context context) {
-        return isPreComputed() ? preComputed : executeImpl(context);
+    public final T execute(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return isPreComputed() ? preComputed : executeImpl(environment, context);
     }
 
     /**
      * Returns a pre computed value if {@link #isPreComputed()} returns true otherwise executes this element.
      * If the result is not an instance of the specified {@link Class} an {@link ExecutionException} is thrown.
      *
+     * @param environment the environment this code is being executed in, may be null if the code is expected to be pre computed
      * @param context the context this code is being executed in, may be null if the code is expected to be pre computed
      * @param forcedResult the {@link Class} this method must return an instance of
      * @param <R> the type this method must return an instance of
@@ -64,8 +67,8 @@ public abstract class PsiElement<T> {
      * @since 0.1.0
      */
     @NotNull
-    public <R> R execute(@Nullable Context context, @NotNull Class<R> forcedResult) {
-        T result = execute(context);
+    public <R> R execute(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull Class<R> forcedResult) {
+        T result = execute(environment, context);
 
         if (forcedResult.isInstance(result)) {
             return forcedResult.cast(result);
@@ -84,7 +87,7 @@ public abstract class PsiElement<T> {
      * @since 0.1.0
      */
     @Nullable
-    protected T executeImpl(@Nullable Context context) {
+    protected T executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         throw new UnsupportedOperationException("Cannot execute expression without implementation.");
     }
 

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/PsiSection.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/PsiSection.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.core.psi;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.util.pointermovement.ExitSectionsPointerMovement;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,16 +36,16 @@ public abstract class PsiSection extends PsiElement<ExitSectionsPointerMovement>
         this.elements = elements;
 
         if (Arrays.stream(elements).anyMatch(element -> element.isPreComputed()
-                && element.execute(null) instanceof Boolean)) {
+                && element.execute(null, null) instanceof Boolean)) {
             //TODO warning
         }
     }
 
     @Nullable
     @Override
-    protected ExitSectionsPointerMovement executeImpl(@Nullable Context context) {
+    protected ExitSectionsPointerMovement executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         for (PsiElement<?> element : elements) {
-            if (element.execute(context) == Boolean.FALSE) {
+            if (element.execute(environment, context) == Boolean.FALSE) {
                 break;
             }
         }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiChanceCondition.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiChanceCondition.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.condition;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptMatchResult;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.pattern.group.OptionalGroup;
@@ -51,8 +52,8 @@ public class PsiChanceCondition extends PsiElement<Boolean> {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return ThreadLocalRandom.current().nextDouble(asPercentage ? 100 : 1) < number.execute(context, Double.class);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return ThreadLocalRandom.current().nextDouble(asPercentage ? 100 : 1) < number.execute(environment, context, Double.class);
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiEndsWithCondition.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiEndsWithCondition.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.condition;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -51,7 +52,7 @@ public class PsiEndsWithCondition extends PsiElement<Boolean> {
         this.positive = positive;
 
         if (text.isPreComputed() && suffix.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.text = null;
             this.suffix = null;
@@ -61,10 +62,10 @@ public class PsiEndsWithCondition extends PsiElement<Boolean> {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        Text text = this.text.execute(context, Text.class);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Text text = this.text.execute(environment, context, Text.class);
 
-        return positive == text.toString().endsWith(suffix.execute(context, Text.class).toString());
+        return positive == text.toString().endsWith(suffix.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiExistsCondition.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiExistsCondition.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.condition;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -40,7 +41,7 @@ public class PsiExistsCondition extends PsiElement<Boolean> {
         this.positive = positive;
 
         if (object.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.object = null;
         }
     }
@@ -48,8 +49,8 @@ public class PsiExistsCondition extends PsiElement<Boolean> {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        return positive == (object.execute(context) != null);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return positive == (object.execute(environment, context) != null);
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiIsCondition.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiIsCondition.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.condition;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -46,7 +47,7 @@ public class PsiIsCondition extends PsiElement<Boolean> {
 
         if (this.leftSide.isPreComputed() && this.rightSide.isPreComputed()) {
             //TODO: Show warning
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.leftSide = null;
             this.rightSide = null;
         }
@@ -54,9 +55,9 @@ public class PsiIsCondition extends PsiElement<Boolean> {
 
     @Nullable
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        Object leftResult = leftSide.execute(context);
-        Object rightResult = rightSide.execute(context);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object leftResult = leftSide.execute(environment, context);
+        Object rightResult = rightSide.execute(environment, context);
 
         if (leftResult == null && rightResult == null) {
             return true;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiStartsWithCondition.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/condition/PsiStartsWithCondition.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.condition;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -51,7 +52,7 @@ public class PsiStartsWithCondition extends PsiElement<Boolean> {
         this.positive = positive;
 
         if (text.isPreComputed() && prefix.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.text = null;
             this.prefix = null;
@@ -61,10 +62,10 @@ public class PsiStartsWithCondition extends PsiElement<Boolean> {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Boolean executeImpl(@Nullable Context context) {
-        Text text = this.text.execute(context, Text.class);
+    protected Boolean executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Text text = this.text.execute(environment, context, Text.class);
 
-        return positive == text.toString().startsWith(prefix.execute(context, Text.class).toString());
+        return positive == text.toString().startsWith(prefix.execute(environment, context, Text.class).toString());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/effect/PsiChangeEffect.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/effect/PsiChangeEffect.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.effect;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -57,19 +58,19 @@ public class PsiChangeEffect extends PsiElement<Void> {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (changeMode == ChangeMode.ADD && changee instanceof Addable) {
-            ((Addable) changee).add(context, Objects.requireNonNull(objects));
+            ((Addable) changee).add(environment, context, Objects.requireNonNull(objects));
         } else if (changeMode == ChangeMode.SET && changee instanceof Settable) {
-            ((Settable) changee).set(context, Objects.requireNonNull(objects));
+            ((Settable) changee).set(environment, context, Objects.requireNonNull(objects));
         } else if (changeMode == ChangeMode.REMOVE_ALL && changee instanceof RemoveAllable) {
-            ((RemoveAllable) changee).removeAll(context, Objects.requireNonNull(objects));
+            ((RemoveAllable) changee).removeAll(environment, context, Objects.requireNonNull(objects));
         } else if (changeMode == ChangeMode.REMOVE && changee instanceof Removable) {
-            ((Removable) changee).remove(context, Objects.requireNonNull(objects));
+            ((Removable) changee).remove(environment, context, Objects.requireNonNull(objects));
         } else if (changeMode == ChangeMode.DELETE && changee instanceof Deletable) {
-            ((Deletable) changee).delete(context);
+            ((Deletable) changee).delete(environment, context);
         } else if (changeMode == ChangeMode.RESET && changee instanceof Resettable) {
-            ((Resettable) changee).reset(context);
+            ((Resettable) changee).reset(environment, context);
         } else {
             throw new ExecutionException("Specified change cannot be applied on the given expression", lineNumber);
         }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/effect/PsiDoIfEffect.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/effect/PsiDoIfEffect.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.effect;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptMatchResult;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.pattern.group.RegexGroup;
@@ -53,9 +54,9 @@ public class PsiDoIfEffect extends PsiElement<Void> {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        if (condition.execute(context, Boolean.class)) {
-            expression.execute(context);
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        if (condition.execute(environment, context, Boolean.class)) {
+            expression.execute(environment, context);
         }
 
         return null;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/effect/PsiLogEffect.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/effect/PsiLogEffect.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.effect;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -54,15 +55,15 @@ public class PsiLogEffect extends PsiElement<Void> {
 
     @Nullable
     @Override
-    protected Void executeImpl(@Nullable Context context) {
-        String text = this.text.execute(context, Text.class).toString();
+    protected Void executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        String text = this.text.execute(environment, context, Text.class).toString();
 
         if (fileName == null) {
             String prefix = context == null ? "" : '[' + context.getSkript().getName() + "] ";
 
             System.out.println(prefix + text);
         } else {
-            String fileName = this.fileName.execute(context, Text.class).toString();
+            String fileName = this.fileName.execute(environment, context, Text.class).toString();
 
             if (!fileName.endsWith(".log")) {
                 fileName += ".log";

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiAlphabeticalSortExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiAlphabeticalSortExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -36,7 +37,7 @@ public class PsiAlphabeticalSortExpression extends PsiElement<Text[]> {
         this.texts = texts;
 
         if (texts.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.texts = null;
         }
@@ -45,8 +46,8 @@ public class PsiAlphabeticalSortExpression extends PsiElement<Text[]> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text[] executeImpl(@Nullable Context context) {
-        Object result = this.texts.execute(context);
+    protected Text[] executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object result = this.texts.execute(environment, context);
         return PsiCollection.toStreamForgiving(result)
                 .map(e -> (Text) e)
                 .sorted()

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiAmountExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiAmountExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -36,7 +37,7 @@ public class PsiAmountExpression extends PsiElement<Number> {
         this.collection = collection;
 
         if (collection.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.collection = null;
         }
@@ -45,8 +46,8 @@ public class PsiAmountExpression extends PsiElement<Number> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Number executeImpl(@Nullable Context context) {
-        Object object = collection.execute(context);
+    protected Number executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = collection.execute(environment, context);
 
         if (object == null) {
             throw new ExecutionException("Object is null", lineNumber);

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiArithmeticExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiArithmeticExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -43,7 +44,7 @@ public class PsiArithmeticExpression extends PsiElement<Number> {
         this.operation = operation;
 
         if (left.isPreComputed() && right.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.left = null;
             this.right = null;
@@ -54,9 +55,9 @@ public class PsiArithmeticExpression extends PsiElement<Number> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Number executeImpl(@Nullable Context context) {
-        double leftNumber = left.execute(context, Number.class).doubleValue();
-        double rightNumber = right.execute(context, Number.class).doubleValue();
+    protected Number executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        double leftNumber = left.execute(environment, context, Number.class).doubleValue();
+        double rightNumber = right.execute(environment, context, Number.class).doubleValue();
 
         switch (operation) {
             case ADDITION:

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiCapitalizationTextExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiCapitalizationTextExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -45,7 +46,7 @@ public class PsiCapitalizationTextExpression extends PsiElement<Text> {
         this.text = text;
 
         if (text.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.capitalization = null;
             this.text = null;
@@ -54,8 +55,8 @@ public class PsiCapitalizationTextExpression extends PsiElement<Text> {
 
     @Nullable
     @Override
-    protected Text executeImpl(@Nullable Context context) {
-        String text = this.text.execute(context, Text.class).toString();
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        String text = this.text.execute(environment, context, Text.class).toString();
         Locale locale = Locale.getDefault();
         StringBuilder newText = new StringBuilder(text.length());
 

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiDefaultValueExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiDefaultValueExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -40,7 +41,7 @@ public class PsiDefaultValueExpression extends PsiElement<Object> {
         this.defaultValue = defaultValue;
 
         if (this.value.isPreComputed() && this.defaultValue.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.value = null;
             this.defaultValue = null;
@@ -50,11 +51,11 @@ public class PsiDefaultValueExpression extends PsiElement<Object> {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Object executeImpl(@Nullable Context context) {
-        Object value = this.value.execute(context);
+    protected Object executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object value = this.value.execute(environment, context);
 
         if (value == null) {
-            return defaultValue.execute(context);
+            return defaultValue.execute(environment, context);
         }
 
         return value;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiFilterExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiFilterExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptMatchResult;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.pattern.group.RegexGroup;
@@ -59,13 +60,13 @@ public class PsiFilterExpression extends PsiElement<Object> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Object executeImpl(@Nullable Context context) {
-        Object object = collection.execute(context);
+    protected Object executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = collection.execute(environment, context);
 
         List<Object> list = new ArrayList<>();
         PsiCollection.forEach(object, e -> {
             currentLoopingElement = e;
-            if (predicate.execute(context, Boolean.class)) {
+            if (predicate.execute(environment, context, Boolean.class)) {
                 list.add(e);
             }
         }, null);

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiFilterInputExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiFilterInputExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -37,7 +38,7 @@ public class PsiFilterInputExpression extends PsiElement<Object> {
 
     @Nullable
     @Override
-    protected Object executeImpl(@Nullable Context context) {
+    protected Object executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         PsiElement<?> element = this;
 
         do {

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiFormatDateTimeExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiFormatDateTimeExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -44,7 +45,7 @@ public class PsiFormatDateTimeExpression extends PsiElement<String> {
         this.format = format;
 
         if (this.dateTime.isPreComputed() && (this.format == null || this.format.isPreComputed())) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.dateTime = null;
             this.format = null;
@@ -53,12 +54,12 @@ public class PsiFormatDateTimeExpression extends PsiElement<String> {
 
     @Nullable
     @Override
-    protected String executeImpl(@Nullable Context context) {
-        String pattern = this.format == null ? "yyyy-MM-dd HH:mm:ss z" : format.execute(context, String.class);
+    protected String executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        String pattern = this.format == null ? "yyyy-MM-dd HH:mm:ss z" : format.execute(environment, context, String.class);
 
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(pattern).withZone(ZoneId.systemDefault());
 
-        return dateTime.execute(context, LocalDateTime.class).format(dateTimeFormatter);
+        return dateTime.execute(environment, context, LocalDateTime.class).format(dateTimeFormatter);
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiHashExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiHashExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -45,7 +46,7 @@ public class PsiHashExpression extends PsiElement<String> {
         this.messageDigest = messageDigest;
 
         if (this.text.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.text = null;
             this.messageDigest = null;
@@ -54,8 +55,8 @@ public class PsiHashExpression extends PsiElement<String> {
 
     @Nullable
     @Override
-    protected String executeImpl(@Nullable Context context) {
-        Object object = text.execute(context);
+    protected String executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = text.execute(environment, context);
 
         if (object == null) {
             throw new ExecutionException("Text should not be null", lineNumber);

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiIndexOfExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiIndexOfExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -45,7 +46,7 @@ public class PsiIndexOfExpression extends PsiElement<Integer> {
         this.searchPosition = searchPos;
 
         if (needle.isPreComputed() && haystack.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.haystack = null;
             this.needle = null;
@@ -56,9 +57,9 @@ public class PsiIndexOfExpression extends PsiElement<Integer> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
-        String needle = this.needle.execute(context, Text.class).toString();
-        String haystack = this.haystack.execute(context, Text.class).toString();
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        String needle = this.needle.execute(environment, context, Text.class).toString();
+        String haystack = this.haystack.execute(environment, context, Text.class).toString();
         int index;
 
         if (searchPosition == SearchPosition.FIRST) {

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiIndicesExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiIndicesExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -38,7 +39,7 @@ public class PsiIndicesExpression extends PsiElement<int[]> {
         this.collection = collection;
 
         if (collection.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.collection = null;
         }
@@ -47,8 +48,8 @@ public class PsiIndicesExpression extends PsiElement<int[]> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected int[] executeImpl(@Nullable Context context) {
-        Object object = collection.execute(context);
+    protected int[] executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = collection.execute(environment, context);
         int size = PsiCollection.getSize(object, -1);
 
         if (size == -1) {

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiInfinityExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiInfinityExpression.java
@@ -1,7 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
-import com.github.stefvanschie.quickskript.core.pattern.SkriptMatchResult;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -35,14 +35,14 @@ public class PsiInfinityExpression extends PsiElement<Double> {
 
         this.sign = sign;
 
-        preComputed = executeImpl(null);
+        preComputed = executeImpl(null, null);
 
         this.sign = null;
     }
 
     @Nullable
     @Override
-    protected Double executeImpl(@Nullable Context context) {
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (sign == Sign.POSITIVE) {
             return Double.POSITIVE_INFINITY;
         }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiJoinExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiJoinExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -48,7 +49,7 @@ public class PsiJoinExpression extends PsiElement<Text> {
         this.delimiter = delimiter;
 
         if (texts.isPreComputed() && (delimiter == null || delimiter.isPreComputed())) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.texts = null;
             this.delimiter = null;
@@ -58,8 +59,8 @@ public class PsiJoinExpression extends PsiElement<Text> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text executeImpl(@Nullable Context context) {
-        Object object = texts.execute(context);
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = texts.execute(environment, context);
 
         List<Text> texts = new ArrayList<>();
         PsiCollection.forEach(object, e -> {
@@ -73,7 +74,7 @@ public class PsiJoinExpression extends PsiElement<Text> {
             return Text.empty();
         }
 
-        Text delimiter = this.delimiter == null ? Text.parseLiteral(", ") : this.delimiter.execute(context, Text.class);
+        Text delimiter = this.delimiter == null ? Text.parseLiteral(", ") : this.delimiter.execute(environment, context, Text.class);
         List<TextPart> parts = new ArrayList<>(texts.get(0).getParts());
 
         for (int index = 1; index < texts.size(); index++) {

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiLengthExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiLengthExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -35,7 +36,7 @@ public class PsiLengthExpression extends PsiElement<Integer> {
         this.text = text;
 
         if (text.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.text = null;
         }
@@ -44,8 +45,8 @@ public class PsiLengthExpression extends PsiElement<Integer> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
-        return text.execute(context, Text.class).toString().length();
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return text.execute(environment, context, Text.class).toString().length();
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiNowExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiNowExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -30,7 +31,7 @@ public class PsiNowExpression extends PsiElement<LocalDateTime> {
 
     @Nullable
     @Override
-    protected LocalDateTime executeImpl(@Nullable Context context) {
+    protected LocalDateTime executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return LocalDateTime.now();
     }
 

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiNumbersExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiNumbersExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptMatchResult;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
@@ -48,7 +49,7 @@ public class PsiNumbersExpression extends PsiElement<List<Number>> {
         this.integer = integer;
 
         if (lowerBound.isPreComputed() && upperBound.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.lowerBound = null;
             this.upperBound = null;
@@ -58,11 +59,11 @@ public class PsiNumbersExpression extends PsiElement<List<Number>> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected List<Number> executeImpl(@Nullable Context context) {
+    protected List<Number> executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         List<Number> numbers = new ArrayList<>();
 
-        double lowerBound = this.lowerBound.execute(context, Double.class);
-        double upperBound = this.upperBound.execute(context, Double.class);
+        double lowerBound = this.lowerBound.execute(environment, context, Double.class);
+        double upperBound = this.upperBound.execute(environment, context, Double.class);
 
         int incrementer = lowerBound < upperBound ? 1 : -1;
 

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiParseExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiParseExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptMatchResult;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.pattern.group.RegexGroup;
@@ -50,14 +51,14 @@ public class PsiParseExpression extends PsiElement<Object> {
         this.converter = converter;
 
         if (this.value.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
         }
     }
 
     @Nullable
     @Override
-    protected Object executeImpl(@Nullable Context context) {
-        Object toParse = value.execute(context);
+    protected Object executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object toParse = value.execute(environment, context);
 
         if (toParse == null) {
             return null; //TODO didn't think this through, no idea what should happen, please fix
@@ -70,7 +71,7 @@ public class PsiParseExpression extends PsiElement<Object> {
             return null;
         }
 
-        return parsed.execute(context);
+        return parsed.execute(environment, context);
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiRandomExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiRandomExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -43,8 +44,8 @@ public class PsiRandomExpression extends PsiElement<Object> {
     @Nullable
     @Contract(pure = true)
     @Override
-    protected Object executeImpl(@Nullable Context context) {
-        List<?> list = PsiCollection.toStreamForgiving(collection.execute(context))
+    protected Object executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        List<?> list = PsiCollection.toStreamForgiving(collection.execute(environment, context))
             .collect(Collectors.toUnmodifiableList());
 
         if (list.size() == 0) {

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiRandomNumberExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiRandomNumberExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -52,9 +53,9 @@ public class PsiRandomNumberExpression extends PsiElement<Number> {
 
     @NotNull
     @Override
-    protected Number executeImpl(@Nullable Context context) {
-        Number minNumber = min.execute(context, Number.class);
-        Number maxNumber = max.execute(context, Number.class);
+    protected Number executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Number minNumber = min.execute(environment, context, Number.class);
+        Number maxNumber = max.execute(environment, context, Number.class);
 
         if (minNumber.doubleValue() > maxNumber.doubleValue()) {
             Number temp = maxNumber;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiRoundExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiRoundExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -42,7 +43,7 @@ public class PsiRoundExpression extends PsiElement<Integer> {
         this.roundMode = roundMode;
 
         if (number.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.number = null;
             this.roundMode = null;
@@ -51,17 +52,17 @@ public class PsiRoundExpression extends PsiElement<Integer> {
 
     @NotNull
     @Override
-    protected Integer executeImpl(@Nullable Context context) {
+    protected Integer executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (roundMode == RoundMode.DOWN) {
-            return (int) Math.floor(number.execute(context, Number.class).doubleValue());
+            return (int) Math.floor(number.execute(environment, context, Number.class).doubleValue());
         }
 
         if (roundMode == RoundMode.NEAREST) {
-            return (int) Math.round(number.execute(context, Number.class).doubleValue());
+            return (int) Math.round(number.execute(environment, context, Number.class).doubleValue());
         }
 
         if (roundMode == RoundMode.UP) {
-            return (int) Math.ceil(number.execute(context, Number.class).doubleValue());
+            return (int) Math.ceil(number.execute(environment, context, Number.class).doubleValue());
         }
 
         throw new ExecutionException(new UnsupportedOperationException("Unknown rounding mode"), lineNumber);

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiScriptNameExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiScriptNameExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -30,7 +31,7 @@ public class PsiScriptNameExpression extends PsiElement<Text> {
 
     @Nullable
     @Override
-    protected Text executeImpl(@Nullable Context context) {
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (context == null) {
             throw new ExecutionException("Cannot get script name without context", lineNumber);
         }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiShuffleExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiShuffleExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -42,8 +43,8 @@ public class PsiShuffleExpression extends PsiElement<List<?>> {
 
     @Nullable
     @Override
-    protected List<?> executeImpl(@Nullable Context context) {
-        List<?> list = PsiCollection.toStreamForgiving(collection.execute(context)).collect(Collectors.toList());
+    protected List<?> executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        List<?> list = PsiCollection.toStreamForgiving(collection.execute(environment, context)).collect(Collectors.toList());
 
         Collections.shuffle(list);
 

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiSkriptVersionExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiSkriptVersionExpression.java
@@ -1,18 +1,13 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
-import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.core.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.core.psi.util.PsiPrecomputedHolder;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.pattern.Pattern;
 import com.github.stefvanschie.quickskript.core.util.ApplicationInfo;
 import com.github.stefvanschie.quickskript.core.util.text.Text;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
-
-import java.io.IOException;
-import java.util.Properties;
 
 /**
  * Gets the Skript version.

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiSortExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiSortExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -38,7 +39,7 @@ public class PsiSortExpression extends PsiElement<List<?>> {
         this.collection = collection;
 
         if (collection.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.collection = null;
         }
@@ -47,8 +48,8 @@ public class PsiSortExpression extends PsiElement<List<?>> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected List<?> executeImpl(@Nullable Context context) {
-        return PsiCollection.toStreamForgiving(collection.execute(context)).sorted().collect(Collectors.toList());
+    protected List<?> executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return PsiCollection.toStreamForgiving(collection.execute(environment, context)).sorted().collect(Collectors.toList());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiSplitExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiSplitExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -42,7 +43,7 @@ public class PsiSplitExpression extends PsiElement<Text[]> {
         this.delimiter = delimiter;
 
         if (text.isPreComputed() && delimiter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.text = null;
             this.delimiter = null;
@@ -52,9 +53,9 @@ public class PsiSplitExpression extends PsiElement<Text[]> {
     @NotNull
     @Contract(pure = true)
     @Override
-    protected Text[] executeImpl(@Nullable Context context) {
-        String splitPattern = java.util.regex.Pattern.quote(delimiter.execute(context, Text.class).toString());
-        String[] splits = text.execute(context, Text.class).toString().split(splitPattern);
+    protected Text[] executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        String splitPattern = java.util.regex.Pattern.quote(delimiter.execute(environment, context, Text.class).toString());
+        String[] splits = text.execute(environment, context, Text.class).toString().split(splitPattern);
         Text[] texts = new Text[splits.length];
 
         for (int i = 0; i < splits.length; i++) {

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiSubstringExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiSubstringExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -54,15 +55,15 @@ public class PsiSubstringExpression extends PsiElement<Text> {
 
     @Nullable
     @Override
-    protected Text executeImpl(@Nullable Context context) {
-        String text = this.text.execute(context, Text.class).toString();
+    protected Text executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        String text = this.text.execute(environment, context, Text.class).toString();
 
         int startIndex = -1;
 
         if (this.startIndex == null) {
             startIndex = 1;
         } else {
-            int start = this.startIndex.execute(context, Number.class).intValue();
+            int start = this.startIndex.execute(environment, context, Number.class).intValue();
 
             if (relation == PositionRelation.STATIC) {
                 startIndex = start;
@@ -71,7 +72,7 @@ public class PsiSubstringExpression extends PsiElement<Text> {
             }
         }
 
-        int endIndex = this.endIndex == null ? text.length() : this.endIndex.execute(context, Number.class).intValue();
+        int endIndex = this.endIndex == null ? text.length() : this.endIndex.execute(environment, context, Number.class).intValue();
 
         return Text.parse(text.substring(startIndex - 1, endIndex));
     }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiTernaryExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiTernaryExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptMatchResult;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.pattern.group.RegexGroup;
@@ -56,12 +57,12 @@ public class PsiTernaryExpression extends PsiElement<Object> {
         this.elseCode = elseCode;
 
         if (condition.isPreComputed()) {
-            boolean conditionResult = condition.execute(null, Boolean.class);
+            boolean conditionResult = condition.execute(null, null, Boolean.class);
 
             if (conditionResult && ifCode.isPreComputed()) {
-                preComputed = ifCode.execute(null);
+                preComputed = ifCode.execute(null, null);
             } else if (!conditionResult && elseCode.isPreComputed()) {
-                preComputed = elseCode.execute(null);
+                preComputed = elseCode.execute(null, null);
             } else {
                 return;
             }
@@ -74,12 +75,12 @@ public class PsiTernaryExpression extends PsiElement<Object> {
 
     @Nullable
     @Override
-    protected Object executeImpl(@Nullable Context context) {
-        if (condition.execute(context, Boolean.class)) {
-            return ifCode.execute(context);
+    protected Object executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        if (condition.execute(environment, context, Boolean.class)) {
+            return ifCode.execute(environment, context);
         }
 
-        return elseCode.execute(context);
+        return elseCode.execute(environment, context);
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiUnixTimestampExpression.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/PsiUnixTimestampExpression.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -37,7 +38,7 @@ public class PsiUnixTimestampExpression extends PsiElement<Long> {
         this.dateTime = dateTime;
 
         if (dateTime.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.dateTime = null;
         }
@@ -45,8 +46,8 @@ public class PsiUnixTimestampExpression extends PsiElement<Long> {
 
     @Nullable
     @Override
-    protected Long executeImpl(@Nullable Context context) {
-        LocalDateTime dateTime = this.dateTime.execute(context, LocalDateTime.class);
+    protected Long executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        LocalDateTime dateTime = this.dateTime.execute(environment, context, LocalDateTime.class);
 
         return dateTime.toEpochSecond(ZoneId.systemDefault().getRules().getOffset(dateTime));
     }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Addable.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Addable.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.core.psi.expression.util;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,7 +20,7 @@ public interface Addable {
      * @param object the object to add
      * @since 0.1.0
      */
-    default void add(@Nullable Context context, @NotNull PsiElement<?> object) {
+    default void add(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         throw new UnsupportedOperationException("Cannot change expression without implementation.");
     }
 }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Deletable.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Deletable.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression.util;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -16,7 +17,7 @@ public interface Deletable {
      * @param context the context this code is being executed in, or null during pre computation
      * @since 0.1.0
      */
-    default void delete(@Nullable Context context) {
+    default void delete(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         throw new UnsupportedOperationException("Cannot change expression without implementation.");
     }
 }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Removable.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Removable.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.core.psi.expression.util;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,7 +20,7 @@ public interface Removable {
      * @param object the object to remove
      * @since 0.1.0
      */
-    default void remove(@Nullable Context context, @NotNull PsiElement<?> object) {
+    default void remove(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         throw new UnsupportedOperationException("Cannot change expression without implementation.");
     }
 

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/RemoveAllable.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/RemoveAllable.java
@@ -2,11 +2,12 @@ package com.github.stefvanschie.quickskript.core.psi.expression.util;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Indicates that a {@link #removeAll(Context, PsiElement)} operation can be performed on the expression.
+ * Indicates that a {@link #removeAll(SkriptRunEnvironment, Context, PsiElement)} operation can be performed on the expression.
  *
  * @since 0.1.0
  */
@@ -19,7 +20,7 @@ public interface RemoveAllable extends Removable {
      * @param object the object to removed
      * @since 0.1.0
      */
-    default void removeAll(@Nullable Context context, @NotNull PsiElement<?> object) {
+    default void removeAll(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         throw new UnsupportedOperationException("Cannot change expression without implementation.");
     }
 }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Resettable.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Resettable.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.expression.util;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -16,7 +17,7 @@ public interface Resettable {
      * @param context the context this code is being executed in, or null during pre computation
      * @since 0.1.0
      */
-    default void reset(@Nullable Context context) {
+    default void reset(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         throw new UnsupportedOperationException("Cannot change expression without implementation.");
     }
 }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Settable.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/expression/util/Settable.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.core.psi.expression.util;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,7 +20,7 @@ public interface Settable {
      * @param object the object to set
      * @since 0.1.0
      */
-    default void set(@Nullable Context context, @NotNull PsiElement<?> object) {
+    default void set(@Nullable SkriptRunEnvironment environment, @Nullable Context context, @NotNull PsiElement<?> object) {
         throw new UnsupportedOperationException("Cannot change expression without implementation.");
     }
 }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiAbsoluteValueFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiAbsoluteValueFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
@@ -34,15 +35,15 @@ public class PsiAbsoluteValueFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.abs(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.abs(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiAtan2Function.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiAtan2Function.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -39,15 +40,15 @@ public class PsiAtan2Function extends PsiElement<Double> {
         this.y = y;
 
         if (this.x.isPreComputed() && this.y.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.x = this.y = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.atan2(x.execute(context, Number.class).doubleValue(), y.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.atan2(x.execute(environment, context, Number.class).doubleValue(), y.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiCalculateExperienceFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiCalculateExperienceFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiCalculateExperienceFunction extends PsiElement<Long> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Long executeImpl(@Nullable Context context) {
-        long level = parameter.execute(context, Number.class).longValue();
+    protected Long executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        long level = parameter.execute(environment, context, Number.class).longValue();
         if (level <= 0) {
             return 0L;
         }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiCeilFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiCeilFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiCeilFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.ceil(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.ceil(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiCosineFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiCosineFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiCosineFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.cos(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.cos(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiDateFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiDateFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -64,22 +65,22 @@ public class PsiDateFunction extends PsiElement<LocalDateTime> {
             (this.hour == null || this.hour.isPreComputed()) && (this.minute == null || this.minute.isPreComputed()) &&
             (this.second == null || this.second.isPreComputed()) &&
             (this.millisecond == null || this.millisecond.isPreComputed())) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.year = this.month = this.day = this.hour = this.minute = this.second = this.millisecond = null;
         }
     }
 
     @NotNull
     @Override
-    protected LocalDateTime executeImpl(@Nullable Context context) {
+    protected LocalDateTime executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return LocalDateTime.of(
-                year.execute(context, Number.class).intValue(),
-                month.execute(context, Number.class).intValue(),
-                day.execute(context, Number.class).intValue(),
-                hour == null ? 0 : hour.execute(context, Number.class).intValue(),
-                minute == null ? 0 : minute.execute(context, Number.class).intValue(),
-                second == null ? 0 : second.execute(context, Number.class).intValue(),
-                millisecond == null ? 0 : millisecond.execute(context, Number.class).intValue() * 1000000
+                year.execute(environment, context, Number.class).intValue(),
+                month.execute(environment, context, Number.class).intValue(),
+                day.execute(environment, context, Number.class).intValue(),
+                hour == null ? 0 : hour.execute(environment, context, Number.class).intValue(),
+                minute == null ? 0 : minute.execute(environment, context, Number.class).intValue(),
+                second == null ? 0 : second.execute(environment, context, Number.class).intValue(),
+                millisecond == null ? 0 : millisecond.execute(environment, context, Number.class).intValue() * 1000000
         );
     }
 

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiExponentialFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiExponentialFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiExponentialFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.exp(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.exp(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiFloorFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiFloorFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiFloorFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.floor(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.floor(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiInverseCosineFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiInverseCosineFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiInverseCosineFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.acos(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.acos(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiInverseSineFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiInverseSineFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiInverseSineFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.asin(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.asin(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiInverseTangentFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiInverseTangentFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiInverseTangentFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.atan(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.atan(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiLogarithmFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiLogarithmFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -45,18 +46,18 @@ public class PsiLogarithmFunction extends PsiElement<Double> {
         this.base = base;
 
         if (this.value.isPreComputed() && (this.base == null || this.base.isPreComputed())) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.value = this.base = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        double result = Math.log10(value.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        double result = Math.log10(value.execute(environment, context, Number.class).doubleValue());
 
         if (base != null) {
-            result /= base.execute(context, Number.class).doubleValue();
+            result /= base.execute(environment, context, Number.class).doubleValue();
         }
 
         return result;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiMaximumFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiMaximumFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
@@ -41,15 +42,15 @@ public class PsiMaximumFunction extends PsiElement<Double> {
         this.element = element;
 
         if (this.element.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.element = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        Object object = element.execute(context);
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = element.execute(environment, context);
 
         Stream<Object> stream = PsiCollection.toStreamStrict(object);
         if (stream == null) {

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiMinimumFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiMinimumFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
@@ -41,15 +42,15 @@ public class PsiMinimumFunction extends PsiElement<Double> {
         this.element = element;
 
         if (this.element.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.element = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        Object object = element.execute(context);
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = element.execute(environment, context);
 
         Stream<Object> stream = PsiCollection.toStreamStrict(object);
         if (stream == null) {

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiModuloFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiModuloFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -39,15 +40,15 @@ public class PsiModuloFunction extends PsiElement<Double> {
         this.b = b;
 
         if (this.a.isPreComputed() && this.b.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.a = this.b = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return a.execute(context, Number.class).doubleValue() % b.execute(context, Number.class).doubleValue();
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return a.execute(environment, context, Number.class).doubleValue() % b.execute(environment, context, Number.class).doubleValue();
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiNaturalLogarithmFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiNaturalLogarithmFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiNaturalLogarithmFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.log(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.log(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiProductFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiProductFunction.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.psi.util.PsiCollection;
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
@@ -41,15 +42,15 @@ public class PsiProductFunction extends PsiElement<Double> {
         this.element = element;
 
         if (this.element.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.element = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        Object object = element.execute(context);
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = element.execute(environment, context);
 
         Stream<Object> stream = PsiCollection.toStreamStrict(object);
         if (stream == null) {

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiRoundFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiRoundFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiRoundFunction extends PsiElement<Long> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Long executeImpl(@Nullable Context context) {
-        return Math.round(parameter.execute(context, Number.class).doubleValue());
+    protected Long executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.round(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiSineFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiSineFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiSineFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.sin(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.sin(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiSquareRootFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiSquareRootFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiSquareRootFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.sqrt(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.sqrt(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiSumFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiSumFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException;
@@ -41,15 +42,15 @@ public class PsiSumFunction extends PsiElement<Double> {
         this.element = element;
 
         if (this.element.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.element = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        Object object = element.execute(context);
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        Object object = element.execute(environment, context);
 
         double sum = 0;
         Collection<Object> objects = PsiCollection.toCollection(object);

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiTangentFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiTangentFunction.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.function;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
@@ -37,15 +38,15 @@ public class PsiTangentFunction extends PsiElement<Double> {
         this.parameter = parameter;
 
         if (this.parameter.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.parameter = null;
         }
     }
 
     @NotNull
     @Override
-    protected Double executeImpl(@Nullable Context context) {
-        return Math.tan(parameter.execute(context, Number.class).doubleValue());
+    protected Double executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        return Math.tan(parameter.execute(environment, context, Number.class).doubleValue());
     }
 
     /**

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiVectorFunction.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/function/PsiVectorFunction.java
@@ -41,7 +41,7 @@ public class PsiVectorFunction extends PsiElement<Object> {
         this.z = z;
 
         if (this.x.isPreComputed() && this.y.isPreComputed() && this.z.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.x = this.y = this.z = null;
         }
     }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/literal/PsiItemCategoryLiteral.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/literal/PsiItemCategoryLiteral.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.literal;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptMatchResult;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.pattern.group.RegexGroup;
@@ -59,7 +60,7 @@ public class PsiItemCategoryLiteral extends PsiElement<ItemCategory> {
         this.enchantment = enchantment;
 
         if (amount != null && amount.isPreComputed() && enchantment != null && enchantment.isPreComputed()) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.itemCategory = null;
             this.amount = null;
@@ -69,13 +70,13 @@ public class PsiItemCategoryLiteral extends PsiElement<ItemCategory> {
 
     @NotNull
     @Override
-    protected ItemCategory executeImpl(@Nullable Context context) {
+    protected ItemCategory executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         if (amount != null) {
-            itemCategory.setAmount(amount.execute(context, Number.class).intValue());
+            itemCategory.setAmount(amount.execute(environment, context, Number.class).intValue());
         }
 
         if (enchantment != null) {
-            itemCategory.addEnchantment(enchantment.execute(context, Enchantment.class));
+            itemCategory.addEnchantment(enchantment.execute(environment, context, Enchantment.class));
         }
 
         return itemCategory;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/literal/PsiItemLiteral.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/literal/PsiItemLiteral.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.literal;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptMatchResult;
 import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.pattern.group.RegexGroup;
@@ -60,7 +61,7 @@ public class PsiItemLiteral extends PsiElement<Item> {
         this.enchantment = enchantment;
 
         if ((amount == null || amount.isPreComputed()) && (enchantment == null || enchantment.isPreComputed())) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
 
             this.item = null;
             this.amount = null;
@@ -70,11 +71,11 @@ public class PsiItemLiteral extends PsiElement<Item> {
 
     @Nullable
     @Override
-    protected Item executeImpl(@Nullable Context context) {
-        var item = new Item(this.item, amount == null ? 1 : amount.execute(context, Number.class).intValue());
+    protected Item executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
+        var item = new Item(this.item, amount == null ? 1 : amount.execute(environment, context, Number.class).intValue());
 
         if (enchantment != null) {
-            item.setEnchantment(enchantment.execute(context, Enchantment.class));
+            item.setEnchantment(enchantment.execute(environment, context, Enchantment.class));
         }
 
         return item;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/literal/PsiSpawnReasonLiteral.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/literal/PsiSpawnReasonLiteral.java
@@ -3,7 +3,6 @@ package com.github.stefvanschie.quickskript.core.psi.literal;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
 import com.github.stefvanschie.quickskript.core.psi.util.PsiPrecomputedHolder;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
-import com.github.stefvanschie.quickskript.core.psi.util.parsing.pattern.Pattern;
 import com.github.stefvanschie.quickskript.core.util.literal.SpawnReason;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/literal/PsiTimeSpanLiteral.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/literal/PsiTimeSpanLiteral.java
@@ -5,7 +5,6 @@ import com.github.stefvanschie.quickskript.core.pattern.SkriptPattern;
 import com.github.stefvanschie.quickskript.core.pattern.group.RegexGroup;
 import com.github.stefvanschie.quickskript.core.pattern.group.SkriptPatternGroup;
 import com.github.stefvanschie.quickskript.core.psi.PsiElementFactory;
-import com.github.stefvanschie.quickskript.core.psi.exception.ParseException;
 import com.github.stefvanschie.quickskript.core.psi.util.PsiPrecomputedHolder;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.Fallback;
 import com.github.stefvanschie.quickskript.core.psi.util.parsing.pattern.Pattern;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/section/PsiBaseSection.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/section/PsiBaseSection.java
@@ -8,6 +8,7 @@ import com.github.stefvanschie.quickskript.core.psi.exception.ExecutionException
 import com.github.stefvanschie.quickskript.core.psi.util.pointermovement.ExitSectionsPointerMovement;
 import com.github.stefvanschie.quickskript.core.skript.Skript;
 import com.github.stefvanschie.quickskript.core.skript.SkriptLoader;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.skript.profiler.SkriptProfiler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -59,11 +60,11 @@ public class PsiBaseSection extends PsiSection {
 
     @Nullable
     @Override
-    protected ExitSectionsPointerMovement executeImpl(@Nullable Context context) {
+    protected ExitSectionsPointerMovement executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         long startTime = System.nanoTime();
 
         for (PsiElement<?> element : elements) {
-            Object result = element.execute(context);
+            Object result = element.execute(environment, context);
 
             if (result == Boolean.FALSE) {
                 break;
@@ -93,8 +94,10 @@ public class PsiBaseSection extends PsiSection {
             }
         }
 
-        SkriptProfiler.getActive().onTimeMeasured(contextType, profilerIdentifier,
-            System.nanoTime() - startTime);
+        if (environment != null) {
+            environment.getProfiler().onTimeMeasured(contextType, profilerIdentifier,
+                    System.nanoTime() - startTime);
+        }
         return null;
     }
 }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/section/PsiIf.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/section/PsiIf.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.section;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiSection;
 import com.github.stefvanschie.quickskript.core.psi.PsiSectionFactory;
@@ -70,10 +71,10 @@ public class PsiIf extends PsiSection {
 
     @Nullable
     @Override
-    protected ExitSectionsPointerMovement executeImpl(@Nullable Context context) {
+    protected ExitSectionsPointerMovement executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         PsiElement<?>[] elements;
 
-        if (condition.execute(context, Boolean.class)) {
+        if (condition.execute(environment, context, Boolean.class)) {
             elements = this.elements;
         } else if (elseSection != null) {
             elements = elseSection.getElements();
@@ -82,7 +83,7 @@ public class PsiIf extends PsiSection {
         }
 
         for (PsiElement<?> element : elements) {
-            Object result = element.execute(context);
+            Object result = element.execute(environment, context);
 
             if (result == Boolean.FALSE) {
                 break;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/section/PsiWhile.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/section/PsiWhile.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.section;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import com.github.stefvanschie.quickskript.core.psi.PsiSection;
 import com.github.stefvanschie.quickskript.core.psi.PsiSectionFactory;
@@ -48,11 +49,11 @@ public class PsiWhile extends PsiSection {
 
     @Nullable
     @Override
-    protected ExitSectionsPointerMovement executeImpl(@Nullable Context context) {
+    protected ExitSectionsPointerMovement executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         outerLoop:
-        while (condition.execute(context, Boolean.class)) {
+        while (condition.execute(environment, context, Boolean.class)) {
             for (PsiElement<?> element : elements) {
-                Object result = element.execute(context);
+                Object result = element.execute(environment, context);
 
                 if (result == Boolean.FALSE) {
                     break;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/util/PsiCollection.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/util/PsiCollection.java
@@ -2,6 +2,7 @@ package com.github.stefvanschie.quickskript.core.psi.util;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,7 +41,7 @@ public final class PsiCollection<T> extends PsiElement<Collection<T>> {
         this.elements = elements;
 
         if (elements.stream().allMatch(PsiElement::isPreComputed)) {
-            preComputed = executeImpl(null);
+            preComputed = executeImpl(null, null);
             this.elements = null;
         }
     }
@@ -70,9 +71,9 @@ public final class PsiCollection<T> extends PsiElement<Collection<T>> {
 
     @NotNull
     @Override
-    protected Collection<T> executeImpl(@Nullable Context context) {
+    protected Collection<T> executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         return elements.stream()
-                .map(e -> (T) e.execute(context))
+                .map(e -> e.execute(environment, context))
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/util/PsiPrecomputedHolder.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/psi/util/PsiPrecomputedHolder.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.psi.util;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +29,7 @@ public class PsiPrecomputedHolder<T> extends PsiElement<T> {
 
     @Override
     @Contract("_ -> fail")
-    protected final T executeImpl(@Nullable Context context) {
+    protected final T executeImpl(@Nullable SkriptRunEnvironment environment, @Nullable Context context) {
         throw new AssertionError("Since the preComputed variable is always set, this method should never get called");
     }
 }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/skript/SingleLineSkript.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/skript/SingleLineSkript.java
@@ -1,6 +1,7 @@
 package com.github.stefvanschie.quickskript.core.skript;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
+import com.github.stefvanschie.quickskript.core.skript.SkriptRunEnvironment;
 import com.github.stefvanschie.quickskript.core.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -51,7 +52,7 @@ public class SingleLineSkript implements Skript {
      * @return the result of the execution or null if the parsing failed
      */
     @Nullable
-    public Object execute(@NotNull Context context) {
-        return element == null ? null : element.execute(context);
+    public Object execute(@NotNull SkriptRunEnvironment environment, @NotNull Context context) {
+        return element == null ? null : element.execute(environment, context);
     }
 }

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/skript/SkriptLoader.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/skript/SkriptLoader.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.Closeable;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/skript/SkriptRunEnvironment.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/skript/SkriptRunEnvironment.java
@@ -1,0 +1,48 @@
+package com.github.stefvanschie.quickskript.core.skript;
+
+import com.github.stefvanschie.quickskript.core.skript.profiler.NoOpSkriptProfiler;
+import com.github.stefvanschie.quickskript.core.skript.profiler.SkriptProfiler;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The runtime environment (context) in which Skripts can be executed.
+ */
+public class SkriptRunEnvironment {
+
+    /**
+     * The currently active profiler instance.
+     */
+    @NotNull
+    private SkriptProfiler<?> profiler = new NoOpSkriptProfiler();
+
+    /**
+     * Creates and initializes a new instance.
+     */
+    public SkriptRunEnvironment() {}
+
+    /**
+     * Gets the currently active profiler instance.
+     *
+     * @return the current profiler instance
+     */
+    @NotNull
+    @Contract(pure = true)
+    public final SkriptProfiler<?> getProfiler() {
+        return profiler;
+    }
+
+    /**
+     * Sets the profiler to use from now on.
+     * Data from the previous profiler is not transferred to the new one.
+     *
+     * @param profiler the new profiler
+     * @return the previous profiler
+     */
+    @NotNull
+    public SkriptProfiler<?> setProfiler(@NotNull SkriptProfiler<?> profiler) {
+        SkriptProfiler<?> previous = this.profiler;
+        this.profiler = profiler;
+        return previous;
+    }
+}

--- a/core/src/main/java/com/github/stefvanschie/quickskript/core/skript/profiler/SkriptProfiler.java
+++ b/core/src/main/java/com/github/stefvanschie/quickskript/core/skript/profiler/SkriptProfiler.java
@@ -2,7 +2,6 @@ package com.github.stefvanschie.quickskript.core.skript.profiler;
 
 import com.github.stefvanschie.quickskript.core.context.Context;
 import com.github.stefvanschie.quickskript.core.skript.Skript;
-import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,32 +15,6 @@ import java.util.Objects;
  * @since 0.1.0
  */
 public abstract class SkriptProfiler<T> {
-
-    /**
-     * A {@link SkriptProfiler} to be used by all skripts
-     */
-    @NotNull
-    private static SkriptProfiler<?> active = new NoOpSkriptProfiler();
-
-    /**
-     * Gets the current profiler instance.
-     *
-     * @return the profiler instance that is to be used
-     */
-    @NotNull
-    @Contract(pure = true)
-    public static SkriptProfiler<?> getActive() {
-        return active;
-    }
-
-    /**
-     * Sets the current profiler instance.
-     *
-     * @param active the new profiler instance
-     */
-    public static void setActive(@NotNull SkriptProfiler<?> active) {
-        SkriptProfiler.active = active;
-    }
 
     /**
      * Called whenever the code inside an entry point was (successfully) executed.

--- a/core/src/test/java/com/github/stefvanschie/quickskript/core/psi/TestClassBase.java
+++ b/core/src/test/java/com/github/stefvanschie/quickskript/core/psi/TestClassBase.java
@@ -4,7 +4,6 @@ import com.github.stefvanschie.quickskript.core.file.skript.FileSkript;
 import com.github.stefvanschie.quickskript.core.skript.SkriptLoader;
 import com.github.stefvanschie.quickskript.core.skript.StandaloneSkriptLoader;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 

--- a/core/src/test/java/com/github/stefvanschie/quickskript/core/psi/execution/PsiNumberExecutabilityTest.java
+++ b/core/src/test/java/com/github/stefvanschie/quickskript/core/psi/execution/PsiNumberExecutabilityTest.java
@@ -133,7 +133,7 @@ class PsiNumberExecutabilityTest extends TestClassBase {
             RunContext context = new RunContext(supplier);
             PsiElement<Number> result = next(context);
             assertEquals(precomputed, result.isPreComputed());
-            result.execute(null, Number.class);
+            result.execute(null, null, Number.class);
         } catch (ExecutionException e) {
             System.out.println("Acceptable exception was thrown");
         }


### PR DESCRIPTION
Since SkriptLoaders are no longer static static singletons, why should the SkriptProfiler be?